### PR TITLE
Storage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import { example } from './example';
+import { storage } from './storage';
 
-export { example };
+export { example, storage };

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -1,0 +1,156 @@
+import { storage } from './storage';
+
+const testStorage = (
+	storageName: 'localStorage' | 'sessionStorage',
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	fn: any,
+) => {
+	const engine = fn(storageName);
+
+	beforeEach(() => {
+		engine.available = true;
+	});
+
+	afterEach(() => {
+		engine.storage.clear();
+	});
+
+	it(`${storageName} - sets availability if it isn't defined`, () => {
+		engine.available = undefined;
+		expect(engine.isAvailable()).toBe(true);
+		expect(engine.available).toBe(true);
+	});
+
+	it(`${storageName} - returns false for availability when there is an error`, () => {
+		const origStorage = engine.storage;
+
+		// not available, if setItem fails
+		engine.available = undefined;
+		engine.storage = {
+			setItem() {
+				throw new Error('Problem!');
+			},
+		};
+		expect(engine.isAvailable()).toBe(false);
+
+		engine.storage = origStorage;
+	});
+
+	it(`${storageName} - returns cached availability when false`, () => {
+		// Even if setItem works, it still returns false from cache
+		engine.available = false;
+		expect(engine.isAvailable()).toBe(false);
+	});
+
+	it(`${storageName} - returns cached availability, even if broken`, () => {
+		const origStorage = engine.storage;
+
+		// Here setItem is explictly broken but it still uses the cached true value
+		engine.available = true;
+		engine.storage = {
+			setItem() {
+				throw new Error('Problem!');
+			},
+		};
+		expect(engine.isAvailable()).toBe(true);
+
+		engine.storage = origStorage;
+	});
+
+	it(`${storageName} - handles strings`, () => {
+		const myString = 'a dog sat on a mat';
+		engine.set('aString', myString);
+		expect(engine.storage.getItem('aString')).toBe(
+			'{"value":"a dog sat on a mat"}',
+		);
+		expect(engine.get('aString')).toEqual(myString);
+	});
+
+	it(`${storageName} - handles objects`, () => {
+		const myObject = { foo: 'bar' };
+		engine.set('anObject', myObject);
+		expect(engine.storage.getItem('anObject')).toBe(
+			'{"value":{"foo":"bar"}}',
+		);
+		expect(engine.get('anObject')).toEqual(myObject);
+	});
+
+	it(`${storageName} - handles arrays`, () => {
+		const myArray = [true, 2, 'bar'];
+		engine.set('anArray', myArray);
+		expect(engine.storage.getItem('anArray')).toBe(
+			'{"value":[true,2,"bar"]}',
+		);
+		expect(engine.get('anArray')).toEqual(myArray);
+	});
+
+	it(`${storageName} - handles booleans`, () => {
+		engine.set('iAmFalse', false);
+		engine.set('iAmTrue', true);
+		expect(engine.storage.getItem('iAmFalse')).toBe('{"value":false}');
+		expect(engine.storage.getItem('iAmTrue')).toBe('{"value":true}');
+		expect(engine.get('iAmFalse')).toEqual(false);
+		expect(engine.get('iAmTrue')).toEqual(true);
+	});
+
+	it(`${storageName} - handles empty strings`, () => {
+		engine.set('emptyString', '');
+		expect(engine.storage.getItem('emptyString')).toBe('{"value":""}');
+		expect(engine.get('emptyString')).toEqual('');
+	});
+
+	it(`${storageName} - handles null`, () => {
+		engine.set('nullValue', null);
+		expect(engine.storage.getItem('nullValue')).toBe('{"value":null}');
+		expect(engine.get('nullValue')).toEqual(null);
+	});
+
+	it(`${storageName} - handles empty key values`, () => {
+		engine.set('', 'I have no name');
+		expect(engine.storage.getItem('')).toBe('{"value":"I have no name"}');
+		expect(engine.get('')).toEqual('I have no name');
+	});
+
+	it(`${storageName} - handles numbers as key names`, () => {
+		engine.set(6, 'I am six');
+		expect(engine.storage.getItem(6)).toBe('{"value":"I am six"}');
+		expect(engine.get(6)).toEqual('I am six');
+	});
+
+	it(`${storageName} - get() with expired item`, () => {
+		engine.set('iAmExpired', 'data', new Date('1901-01-01'));
+		expect(engine.get('iAmExpired')).toBeNull();
+	});
+
+	it(`${storageName} - get() with non-expired item`, () => {
+		engine.set('iAmNotExpired', 'data', new Date('2040-01-01'));
+		expect(engine.get('iAmNotExpired')).toBeTruthy();
+	});
+
+	it(`${storageName} - getRaw() returns the unparsed string`, () => {
+		const myString = 'a dog sat on a mat';
+		// storage.setItem just sets the string
+		engine.storage.setItem('aString', myString);
+		expect(engine.getRaw('aString')).toBe(myString);
+		// engine.set is our function which sets the string inside an object
+		engine.set('setAsValue', myString);
+		expect(engine.getRaw('setAsValue')).toBe(
+			'{"value":"a dog sat on a mat"}',
+		);
+	});
+
+	it(`${storageName} - remove() deletes the entry`, () => {
+		engine.storage.setItem('deleteMe', 'please delete me');
+		expect(engine.storage.getItem('deleteMe')).toBeTruthy();
+		engine.remove('deleteMe');
+		expect(engine.storage.getItem('deleteMe')).toBeFalsy();
+	});
+};
+
+describe('sessionStorage', () => {
+	testStorage('sessionStorage', storage.session);
+});
+
+describe('localStorage', () => {
+	testStorage('localStorage', storage.local);
+});

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,94 @@
+const store = (type: 'sessionStorage' | 'localStorage') => ({
+	available: undefined as boolean | undefined,
+	storage: window[type],
+	isAvailable(): boolean | undefined {
+		const key = 'local-storage-test';
+
+		if (this.available !== undefined) {
+			return this.available;
+		}
+
+		try {
+			// to fully test, need to set item
+			// http://stackoverflow.com/questions/9077101/iphone-localstorage-quota-exceeded-err-issue#answer-12976988
+			this.storage.setItem(key, 'graun');
+			this.storage.removeItem(key);
+			this.available = true;
+		} catch (err) {
+			this.available = false;
+		}
+
+		return this.available;
+	},
+
+	get(key: string): unknown | null {
+		if (!this.available) {
+			return;
+		}
+
+		let data;
+
+		// try and parse the data
+		try {
+			const value = this.getRaw(key);
+
+			if (value === null || value === undefined) {
+				return null;
+			}
+
+			data = JSON.parse(value);
+
+			if (data === null) {
+				return null;
+			}
+		} catch (e) {
+			this.remove(key);
+			return null;
+		}
+
+		// has it expired?
+		if (data.expires && new Date() > new Date(data.expires)) {
+			this.remove(key);
+			return null;
+		}
+
+		return data.value;
+	},
+
+	set(
+		key: string,
+		value: unknown,
+		expires?: string | number | Date,
+	): unknown {
+		if (!this.available) {
+			return;
+		}
+
+		return this.storage.setItem(
+			key,
+			JSON.stringify({
+				value,
+				expires,
+			}),
+		);
+	},
+
+	getRaw(key: string): string | null {
+		if (this.available) {
+			return this.storage.getItem(key);
+		}
+		return null;
+	},
+
+	remove(key: string): null | void {
+		if (this.available) {
+			return this.storage.removeItem(key);
+		}
+		return null;
+	},
+});
+
+export const storage = {
+	local: (): unknown => store('localStorage'),
+	session: (): unknown => store('sessionStorage'),
+};

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -42,7 +42,6 @@ const store = (type: 'sessionStorage' | 'localStorage') => ({
 				return null;
 			}
 		} catch (e) {
-			this.remove(key);
 			return null;
 		}
 


### PR DESCRIPTION
## What does this change?
Adds the storage lib from frontend.

## Why should we share this code?
Many codebases use localStorage to persist data but there are some some potential pitfalls around using it that need to be handled. The existing `storage.js` lib in frontend does an excellent job of wrapping `localStorage` (as well as `sessionStorage`) to guard against these pittfalls and also adds additional features such as expiry.

By moving this code up and into @guardian/libs we offer the same error protections and features to all projects.

## Could this code change or will there be new use cases around using it in the future?
This code has reamained unchanged for several years and the same solutions are being repeated in other projects with very little variation (but perhaps not as well as was done in frontend).

## Usage
```typescript
import { storage } from './storage';

const { local, session } = storage;

if (local.isAvailable()) {
  local.set('my-key', {foo: 'my data'});
  local.getRaw('my-key'); // '{"value":{"foo":"my data"}}'
  local.get('my-key'); // {foo: 'my data'}
  local.remove('my-key');

  local.set('expired-key', {foo: 'my data'}, new Date('2001-01-01'));
  local.get('expired-key'); // null
}
```

Please see tests for all use cases