### PR TITLE
Add loadScript

### DIFF
--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -1,7 +1,0 @@
-import { example } from './example';
-
-describe('example', () => {
-	it('should want to be deleted', () => {
-		expect(example().deleteme).toBe(true);
-	});
-});

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,7 +1,0 @@
-import { exampleType } from './types';
-
-export const example = (): exampleType => {
-	return {
-		deleteme: true,
-	};
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,1 @@
-import { example } from './example';
-
-export { example };
+export { loadScript } from './loadScript';

--- a/src/loadScript.test.ts
+++ b/src/loadScript.test.ts
@@ -61,9 +61,11 @@ describe('loadScript', () => {
 		await loadScript(goodURL, {
 			async: true,
 			referrerPolicy: 'no-referrer',
+			className: 'u6ytfiuyoibnpoim',
 		});
-		expect(getTestScript(goodURL)?.async).toBeTruthy();
-		expect(getTestScript(goodURL)?.referrerPolicy).toBe('no-referrer');
+		expect(document.scripts[0]?.async).toBeTruthy();
+		expect(document.scripts[0]?.referrerPolicy).toBe('no-referrer');
+		expect(document.scripts[0]?.className).toBe('u6ytfiuyoibnpoim');
 	});
 
 	it('rejects if the script fails to load', async () => {

--- a/src/loadScript.test.ts
+++ b/src/loadScript.test.ts
@@ -7,31 +7,29 @@ const badURL = 'bad-url';
 // when we detect that a script has been added to the DOM:
 // - if the src is goodURL trigger a load event
 // - if the src is badURL trigger an error event
-const fakeLoader = new MutationObserver((mutations) => {
+new MutationObserver((mutations) => {
 	mutations.forEach((mutation) => {
 		mutation.addedNodes.forEach((addedNode) => {
 			if (addedNode.nodeName === 'SCRIPT') {
-				if ((addedNode as HTMLScriptElement).src.includes(goodURL)) {
+				const addedScript = addedNode as HTMLScriptElement;
+
+				if (addedScript.src.includes(goodURL)) {
 					addedNode.dispatchEvent(new Event('load'));
 				}
-				if ((addedNode as HTMLScriptElement).src.includes(badURL)) {
+
+				if (addedScript.src.includes(badURL)) {
 					addedNode.dispatchEvent(new Event('error'));
 				}
 			}
 		});
 	});
+}).observe(document.body, {
+	childList: true,
 });
 
 beforeEach(() => {
 	document.body.innerHTML = '';
 	document.body.appendChild(document.createElement('script'));
-	fakeLoader.observe(document.body, {
-		childList: true,
-	});
-});
-
-afterEach(() => {
-	fakeLoader.disconnect();
 });
 
 describe('loadScript', () => {

--- a/src/loadScript.test.ts
+++ b/src/loadScript.test.ts
@@ -57,6 +57,16 @@ describe('loadScript', () => {
 		expect(document.scripts).toHaveLength(2);
 	});
 
+	it('does not inject duplicate scripts if they are called with and without protocol', async () => {
+		expect(document.scripts).toHaveLength(1);
+		await expect(loadScript(`//${goodURL}`)).resolves.toMatchObject({
+			type: 'load',
+		});
+		// try injecting it again with a full protocol (http-only because we're in jest)
+		await expect(loadScript(`http://${goodURL}`)).resolves.toBeUndefined();
+		expect(document.scripts).toHaveLength(2);
+	});
+
 	it('can add scripts with attributes', async () => {
 		await loadScript(goodURL, {
 			async: true,

--- a/src/loadScript.test.ts
+++ b/src/loadScript.test.ts
@@ -50,6 +50,7 @@ describe('loadScript', () => {
 		await expect(loadScript(goodURL)).resolves.toMatchObject({
 			type: 'load',
 		});
+		// try injecting it again a random amount of times
 		await expect(loadScript(goodURL)).resolves.toBeUndefined();
 		await expect(loadScript(goodURL)).resolves.toBeUndefined();
 		await expect(loadScript(goodURL)).resolves.toBeUndefined();

--- a/src/loadScript.test.ts
+++ b/src/loadScript.test.ts
@@ -10,15 +10,13 @@ const badURL = 'bad-url';
 const fakeLoader = new MutationObserver((mutations) => {
 	mutations.forEach((mutation) => {
 		mutation.addedNodes.forEach((addedNode) => {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			if (addedNode.src.includes(goodURL)) {
-				addedNode.dispatchEvent(new Event('load'));
-			}
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			if (addedNode.src.includes(badURL)) {
-				addedNode.dispatchEvent(new Event('error'));
+			if (addedNode.nodeName === 'SCRIPT') {
+				if ((addedNode as HTMLScriptElement).src.includes(goodURL)) {
+					addedNode.dispatchEvent(new Event('load'));
+				}
+				if ((addedNode as HTMLScriptElement).src.includes(badURL)) {
+					addedNode.dispatchEvent(new Event('error'));
+				}
 			}
 		});
 	});

--- a/src/loadScript.test.ts
+++ b/src/loadScript.test.ts
@@ -1,0 +1,66 @@
+import { loadScript } from './loadScript';
+
+const goodURL = 'good-url';
+const badURL = 'bad-url';
+
+const getTestScript = (url: string) =>
+	Array.from(document.scripts).find(({ src }) => src.includes(url));
+
+const fakeLoadEvent = new MutationObserver((mutations) => {
+	if (
+		mutations.some((mutation) =>
+			Array.from(mutation.addedNodes).some(
+				({ nodeName }) => nodeName === 'SCRIPT',
+			),
+		)
+	) {
+		getTestScript(goodURL)?.onload?.(new Event('fake-onload-event'));
+		getTestScript(badURL)?.onerror?.(new Event('fake-onload-event'));
+	}
+});
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	document.body.appendChild(document.createElement('script'));
+	fakeLoadEvent.observe(document.body, {
+		childList: true,
+	});
+});
+
+afterEach(() => {
+	fakeLoadEvent.disconnect();
+});
+
+describe('loadScript', () => {
+	it('adds a script to the page and resolves the promise it returns when the script loads', async () => {
+		expect(document.scripts).toHaveLength(1);
+		await expect(loadScript(goodURL)).resolves.toMatchObject({
+			type: 'fake-onload-event',
+		});
+		expect(document.scripts).toHaveLength(2);
+	});
+
+	it('resolves immediately if a script with matching src is already on page and stops there', async () => {
+		expect(document.scripts).toHaveLength(1);
+		await expect(loadScript(goodURL)).resolves.toMatchObject({
+			type: 'fake-onload-event',
+		});
+		await expect(loadScript(goodURL)).resolves.toBeUndefined();
+		await expect(loadScript(goodURL)).resolves.toBeUndefined();
+		await expect(loadScript(goodURL)).resolves.toBeUndefined();
+		expect(document.scripts).toHaveLength(2);
+	});
+
+	it('can add scripts with attributes', async () => {
+		await loadScript(goodURL, {
+			async: true,
+			referrerPolicy: 'no-referrer',
+		});
+		expect(getTestScript(goodURL)?.async).toBeTruthy();
+		expect(getTestScript(goodURL)?.referrerPolicy).toBe('no-referrer');
+	});
+
+	it('rejects if the script fails to load', async () => {
+		await expect(loadScript(badURL)).rejects.toBeDefined();
+	});
+});

--- a/src/loadScript.ts
+++ b/src/loadScript.ts
@@ -3,15 +3,17 @@ export const loadScript = (
 	props?: Omit<Partial<HTMLScriptElement>, 'src' | 'onload' | ' onerror'>,
 ): Promise<Event | undefined> =>
 	new Promise((resolve, reject) => {
-		if (document.querySelector(`script[src="${src}"]`)) {
+		// creating this before the check below allows us to compare the resolved `src` values
+		const script = document.createElement('script');
+		script.src = src;
+
+		// dont inject 2 scripts with the same src
+		if (Array.from(document.scripts).some(({ src }) => script.src === src)) {
 			return resolve();
 		}
 
-		const script = document.createElement('script');
-
 		Object.assign(script, props);
 
-		script.src = src;
 		script.onload = resolve;
 		script.onerror = () => {
 			reject(new Error(`Failed to load script ${src}`));

--- a/src/loadScript.ts
+++ b/src/loadScript.ts
@@ -1,0 +1,22 @@
+export const loadScript = (
+	src: string,
+	props?: Omit<Partial<HTMLScriptElement>, 'src' | 'onload' | ' onerror'>,
+): Promise<Event | undefined> =>
+	new Promise((resolve, reject) => {
+		if (document.querySelector(`script[src="${src}"]`)) {
+			return resolve();
+		}
+
+		const script = document.createElement('script');
+
+		Object.assign(script, props);
+
+		script.src = src;
+		script.onload = resolve;
+		script.onerror = () => {
+			reject(new Error(`Failed to load script ${src}`));
+		};
+
+		const ref = document.scripts[0];
+		ref?.parentNode?.insertBefore(script, ref);
+	});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,1 @@
-export type exampleType = {
-	deleteme: boolean;
-};
+export {};


### PR DESCRIPTION
## What does this change?

- add `loadScript`, ported/refactored from [frontend](https://github.com/guardian/frontend/blob/main/static/src/javascripts/lib/load-script.js)
- removes stub files

## Why?

- want to use it outside frontend
- will remove in frontend once this is published