### PR TITLE
Enable semantic release on main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -120,4 +120,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release --dry-run
+        run: npx semantic-release


### PR DESCRIPTION
## What does this change?

- enables semantic release on pushes to `main`

## Why?

- so we can use it