### PR TITLE
fix: do not commit bumps to package.json in CD

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -151,6 +151,6 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,6 @@
 	"plugins": [
 		"@semantic-release/commit-analyzer",
 		"@semantic-release/release-notes-generator",
-		"@semantic-release/changelog",
 		"@semantic-release/npm",
 		"@semantic-release/github"
 	]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,6 @@
 		"@semantic-release/release-notes-generator",
 		"@semantic-release/changelog",
 		"@semantic-release/npm",
-		"@semantic-release/github",
-		"@semantic-release/git"
+		"@semantic-release/github"
 	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-# 1.0.0 (2020-10-06)
-
-
-### Features
-
-* **loadscript:** handle script with differing protocols ([c10b262](https://github.com/guardian/libs/commit/c10b2621542ef1de14a5d4821a873c76c0881335))
-* add loadScript ([ae5f3c1](https://github.com/guardian/libs/commit/ae5f3c1535526f2702ab885605b27be7805a5c2e))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/libs",
-	"version": "0.0.0-this-never-updates-in-source",
+	"version": "0.0.0-this-never-updates-in-source-code-refer-to-git-tags",
 	"private": false,
 	"description": "A collection of shared JavaScript libraries for use in Guardian projects",
 	"homepage": "https://github.com/guardian/libs#readme",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
 		}
 	},
 	"devDependencies": {
-		"@semantic-release/changelog": "^5.0.1",
-		"@semantic-release/git": "^9.0.0",
 		"@semantic-release/github": "^7.1.1",
 		"@types/jest": "^26.0.14",
 		"@typescript-eslint/eslint-plugin": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/libs",
-	"version": "1.0.0",
+	"version": "0.0.0-this-never-updates-in-source",
 	"private": false,
 	"description": "A collection of shared JavaScript libraries for use in Guardian projects",
 	"homepage": "https://github.com/guardian/libs#readme",

--- a/yarn.lock
+++ b/yarn.lock
@@ -640,16 +640,6 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@semantic-release/changelog@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@semantic-release/changelog/-/changelog-5.0.1.tgz#50a84b63e5d391b7debfe021421589fa2bcdafe4"
-  integrity sha512-unvqHo5jk4dvAf2nZ3aw4imrlwQ2I50eVVvq9D47Qc3R+keNqepx1vDYwkjF8guFXnOYaYcR28yrZWno1hFbiw==
-  dependencies:
-    "@semantic-release/error" "^2.1.0"
-    aggregate-error "^3.0.0"
-    fs-extra "^9.0.0"
-    lodash "^4.17.4"
-
 "@semantic-release/commit-analyzer@^8.0.0":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-8.0.1.tgz#5d2a37cd5a3312da0e3ac05b1ca348bf60b90bca"
@@ -663,24 +653,10 @@
     lodash "^4.17.4"
     micromatch "^4.0.2"
 
-"@semantic-release/error@^2.1.0", "@semantic-release/error@^2.2.0":
+"@semantic-release/error@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
   integrity sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==
-
-"@semantic-release/git@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-9.0.0.tgz#304c4883c87d095b1faaae93300f1f1e0466e9a5"
-  integrity sha512-AZ4Zha5NAPAciIJH3ipzw/WU9qLAn8ENaoVAhD6srRPxTpTzuV3NhNh14rcAo8Paj9dO+5u4rTKcpetOBluYVw==
-  dependencies:
-    "@semantic-release/error" "^2.1.0"
-    aggregate-error "^3.0.0"
-    debug "^4.0.0"
-    dir-glob "^3.0.0"
-    execa "^4.0.0"
-    lodash "^4.17.4"
-    micromatch "^4.0.0"
-    p-reduce "^2.0.0"
 
 "@semantic-release/github@^7.0.0", "@semantic-release/github@^7.1.1":
   version "7.1.1"
@@ -4951,7 +4927,7 @@ micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.0, micromatch@^4.0.2:
+micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
   integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==


### PR DESCRIPTION
## What does this change?

- stops committing bumps to `package.json` and `CHANGELOG.md` when releasing

## Why?

- we need an access token with admin rights to do it, which the default GitHub user in actions does not have
- they aren't needed – releases will still be tagged in git, and available from NPM and GitHub with the correct version in `package.json`, it just won't be committed to `main`
- messages like https://github.com/guardian/commercial-core/pull/58#issuecomment-708456726 won't come from me!

_nb fix: prefix is just to force a patch release on merge to test it_