### PR TITLE
fix: update Storage#get return type

### DIFF
--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -53,6 +53,7 @@ describe.each([
 		// re-import now we've disabled native storage API
 		const { storage } = await import('./storage');
 		expect(() => storage[name].set('🚫', true)).not.toThrowError();
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return -- it's correct
 		expect(() => storage[name].get('🚫')).not.toThrowError();
 		expect(() => storage[name].remove('🚫')).not.toThrowError();
 		expect(() => storage[name].getRaw('🚫')).not.toThrowError();

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -38,23 +38,27 @@ class Storage {
 		}
 	}
 
+	/* eslint-disable
+		@typescript-eslint/no-unsafe-assignment,
+		@typescript-eslint/no-unsafe-return,
+		@typescript-eslint/no-explicit-any
+		--
+		- we're using the `try` to handle anything bad happening
+		- JSON.parse returns an `any`, we really are returning an `any`
+	*/
 	/**
 	 * Retrieve an item from storage.
 	 *
 	 * @param key - the name of the item
 	 */
-	get(key: string): unknown {
+	get(key: string): any {
 		if (this.isAvailable()) {
 			try {
-				/* eslint-disable @typescript-eslint/no-unsafe-assignment --
-				we're using the `try` to handle anything bad happening */
 				const { value, expires } = JSON.parse(
 					this.__storage.getItem(key) ?? '',
 				);
-				/* eslint-enable @typescript-eslint/no-unsafe-assignment */
 
-				// is this item has passed its sell-by-date,
-				// remove it and return null
+				// is this item has passed its sell-by-date, remove it
 				if (expires && new Date() > new Date(expires)) {
 					this.remove(key);
 					return null;
@@ -66,6 +70,11 @@ class Storage {
 			}
 		}
 	}
+	/* eslint-enable
+		@typescript-eslint/no-unsafe-assignment,
+		@typescript-eslint/no-unsafe-return,
+		@typescript-eslint/no-explicit-any
+	*/
 
 	/**
 	 * Save a value to storage.


### PR DESCRIPTION
# What does this change?

- explicitly returns an `any` from `Storage#get` because that's what `JSON.parse` does

## Why?

- an `unknown` is inaccurate, and makes this method harder to use than using `JSON.parse` itself, which it shouldn't
