### PR TITLE
perf: cache the value of locale on first successful lookup

### DIFF
--- a/src/getLocale.test.ts
+++ b/src/getLocale.test.ts
@@ -22,6 +22,7 @@ describe('getLocale', () => {
 		fetchMock.mockResponseOnce(JSON.stringify({ country: 'CZ' }));
 		const locale = await getLocale();
 		expect(locale).toBe('CZ');
+		expect(storage.local.get(KEY)).toBe('CZ');
 	});
 
 	it('ignores a stored invalid locale', async () => {
@@ -44,5 +45,17 @@ describe('getLocale', () => {
 		const locale = await getLocale();
 		expect(locale).toBeNull();
 		expect(storage.local.get(KEY)).toBeNull();
+	});
+
+	it('uses the cached value if available', async () => {
+		const spy = jest.spyOn(storage.local, 'get');
+
+		storage.local.set(KEY, 'CY');
+		const locale = await getLocale();
+		const locale2 = await getLocale();
+
+		expect(locale).toBe(locale2);
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/src/getLocale.test.ts
+++ b/src/getLocale.test.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'jest-fetch-mock';
-import { getLocale } from './getLocale';
+import { __resetCachedValue, getLocale } from './getLocale';
 import { storage } from './storage';
 
 const KEY = 'gu.geolocation';
@@ -9,6 +9,7 @@ fetchMock.enableMocks();
 describe('getLocale', () => {
 	beforeEach(() => {
 		storage.local.clear();
+		__resetCachedValue();
 	});
 
 	it('gets a stored valid locale', async () => {

--- a/src/getLocale.ts
+++ b/src/getLocale.ts
@@ -12,16 +12,24 @@ const isValidCountryCode = (country: unknown) =>
 const daysFromNow = (days: number) =>
 	new Date().getTime() + 60 * 60 * 24 * days;
 
+// we'll cache any successful lookups so we only have to do this once
+let locale: CountryCode | undefined;
+
+// just used for tests
+export const __resetCachedValue = (): void => (locale = void 0);
+
 /**
  * Fetches the user's current location as an ISO 3166-1 alpha-2 string e.g. 'GB', 'AU' etc
  */
 
 export const getLocale = async (): Promise<CountryCode | null> => {
+	if (locale) return locale;
+
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- it _is_ any
 	const stored = storage.local.get(KEY);
 
 	// if we've got a locale, return it
-	if (isValidCountryCode(stored)) return stored as CountryCode;
+	if (isValidCountryCode(stored)) return (locale = stored as CountryCode);
 
 	// use our API to get one
 	try {
@@ -35,7 +43,7 @@ export const getLocale = async (): Promise<CountryCode | null> => {
 			storage.local.set(KEY, country, daysFromNow(10));
 
 			// return it
-			return country as CountryCode;
+			return (locale = country as CountryCode);
 		}
 	} catch (e) {
 		// do nothing


### PR DESCRIPTION
## What does this change?

only performs locale lookup once, uses the found value after that

## Why?

does less work, and looking in `localStorage` is a blocking action