### PR TITLE
fix: getLocale types

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   "author": "Guardian developers",
   "sideEffects": false,
   "main": "dist/cjs/index.js",
+  "unpkg": "dist/umd/index.min.js",
   "module": "dist/esm/index.js",
   "source": "src/index.ts",
-  "unpkg": "dist/umd/index.min.js",
+  "types": "dist/esm/index.d.ts",
   "files": [
     "dist",
     "src"

--- a/src/getLocale.ts
+++ b/src/getLocale.ts
@@ -25,25 +25,23 @@ export const __resetCachedValue = (): void => (locale = void 0);
 export const getLocale = async (): Promise<CountryCode | null> => {
 	if (locale) return locale;
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- it _is_ any
-	const stored = storage.local.get(KEY);
+	const stored = storage.local.get(KEY) as CountryCode;
 
 	// if we've got a locale, return it
-	if (isValidCountryCode(stored)) return (locale = stored as CountryCode);
+	if (isValidCountryCode(stored)) return (locale = stored);
 
 	// use our API to get one
 	try {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- it's json
-		const { country } = await fetch(URL).then((response) =>
+		const { country } = (await fetch(URL).then((response) =>
 			response.json(),
-		);
+		)) as { country: CountryCode };
 
 		if (isValidCountryCode(country)) {
 			// save it for 10 days
 			storage.local.set(KEY, country, daysFromNow(10));
 
 			// return it
-			return (locale = country as CountryCode);
+			return (locale = country);
 		}
 	} catch (e) {
 		// do nothing


### PR DESCRIPTION
## What does this change?

- removes the need to disable eslint by asserting the type at right point
- adds `types` field to package 

## Why?

typescript thought `getLocale` returned possible `any` value