### PR TITLE
fix: Add TX Team

### DIFF
--- a/src/logger.teams.ts
+++ b/src/logger.teams.ts
@@ -6,23 +6,23 @@
  * */
 export const teams = {
 	common: {
-		background: '#052962',
-		font: '#ffffff',
+		background: '#052962', // dark blue
+		font: '#ffffff', // white
 	},
 	commercial: {
-		background: '#77EEAA',
-		font: '#004400',
+		background: '#77EEAA', // mint green
+		font: '#004400', // dark green
 	},
 	cmp: {
-		background: '#FF3399',
-		font: '#332020',
+		background: '#FF3399', // bright pink
+		font: '#332020', // dark brown
 	},
 	dotcom: {
-		background: '#000000',
-		font: '#ff7300',
+		background: '#000000', // black
+		font: '#ff7300', // orange
 	},
 	design: {
-		background: '#185E36',
-		font: '#FFF4F2',
+		background: '#185E36', // green
+		font: '#FFF4F2', // light pink
 	},
 };

--- a/src/logger.teams.ts
+++ b/src/logger.teams.ts
@@ -25,4 +25,8 @@ export const teams = {
 		background: '#185E36', // green
 		font: '#FFF4F2', // light pink
 	},
+	tx: {
+		background: '#2F4F4F', // dark slate grey
+		font: '#FFFFFF', // white
+	},
 };


### PR DESCRIPTION
## What does this change?

Adds TX Team.

<img width="65" alt="Screenshot 2021-01-05 at 16 59 58" src="https://user-images.githubusercontent.com/379839/103675834-4e1b1680-4f78-11eb-8734-6eec2645a225.png">

## Why?

So we can start logging with style 😎 

I found it hard to look at a list of hex codes and pick a colour which wasn't already taken, so I've added brief descriptions as comments next to each entry. Please shout if that's not wanted and I'll remove (I've kept the commit separate).