### PR TITLE
chore: use actions-setup-node

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,15 +22,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      # based on https://github.com/actions/setup-node/issues/32#issuecomment-539794249
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup node
-        uses: actions/setup-node@v2.1.4
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -50,15 +43,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      # based on https://github.com/actions/setup-node/issues/32#issuecomment-539794249
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup node
-        uses: actions/setup-node@v2.1.4
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -73,15 +59,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      # based on https://github.com/actions/setup-node/issues/32#issuecomment-539794249
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup node
-        uses: actions/setup-node@v2.1.4
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -96,15 +75,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      # based on https://github.com/actions/setup-node/issues/32#issuecomment-539794249
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup node
-        uses: actions/setup-node@v2.1.4
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -130,15 +102,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # based on https://github.com/actions/setup-node/issues/32#issuecomment-539794249
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-
       - name: Setup node
-        uses: actions/setup-node@v2.1.4
-        with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        uses: guardian/actions-setup-node@main
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

uses https://github.com/guardian/actions-setup-node to manage node in github actions

## Why?

simpler config, one place to manage node version