### PR TITLE
test: improve tests a little

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
 	collectCoverage: true,
 	collectCoverageFrom: ['src/**/*'],
 	coveragePathIgnorePatterns: ['types'],
+	testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
 };

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -5,7 +5,9 @@ import { storage } from './storage';
 
 const KEY = _.KEY;
 
-const spy = jest.spyOn(console, 'log');
+const spy = jest
+	.spyOn(console, 'log')
+	.mockImplementation(() => () => undefined);
 const consoleMessage = (): string | undefined => {
 	if (spy.mock.calls[0] && typeof spy.mock.calls[0][5] === 'string')
 		return spy.mock.calls[0][5];


### PR DESCRIPTION
## What does this change?

- prevents jest looking for tests in `dist`
- stops the `logger` modules tests actually logging

## Why?

- doesn't run pointless tests
- keeps the output cleaner