### PR TITLE
refactor: Remove isValidDate check

### DIFF
--- a/src/timeAgo.ts
+++ b/src/timeAgo.ts
@@ -46,13 +46,6 @@ const isYesterday = (relative: Date): boolean => {
 	return relative.toDateString() === yesterday.toDateString();
 };
 
-const isValidDate = (date: Date): boolean => {
-	if (Object.prototype.toString.call(date) !== '[object Date]') {
-		return false;
-	}
-	return !Number.isNaN(date.getTime());
-};
-
 const getSuffix = (type: Unit, value: number, verbose?: boolean): string => {
 	const shouldPluralise = value !== 1;
 	switch (type) {
@@ -91,12 +84,9 @@ export const timeAgo = (
 ): false | string => {
 	const then = new Date(epoch);
 	const now = new Date();
+
 	const verbose = options?.verbose;
 	const daysUntilAbsolute = options?.daysUntilAbsolute ?? 7;
-
-	if (!isValidDate(then)) {
-		return false;
-	}
 
 	const secondsAgo = Math.floor((now.getTime() - then.getTime()) / 1000);
 	const veryClose = secondsAgo < 15;


### PR DESCRIPTION
## What does this change?
Removes the `isValidDate` function from `dateAgo`

## Why?
I originally started to [abstract this funciton into a lib as](https://trello.com/c/EvexVKCw/2734-move-isvaliddate-into-its-own-helper-util-in-libs) it sounded useful but after thinking some more I realised we don't need it anymore. This function was written 9 years ago as part of the [49th PR for Frontend](https://github.com/guardian/frontend/pull/43/files). Back in 2012 a lot was going on. [Vladimir Putin](https://en.wikipedia.org/wiki/Vladimir_Putin) was elected presedent of Russia, the UK notified the WHO that it had discovered a [novel coronavirus](https://en.wikipedia.org/wiki/2012-nCoV) and [Curiosity](https://en.wikipedia.org/wiki/Curiosity_(rover)) touched down on Mars. In addition to these topical events, Typescript was [first appeared](https://en.wikipedia.org/wiki/TypeScript).

That last point is relevant here. It took a whiile but now Typescript is a thing, we don't need this check. 
