### PR TITLE
feat: Get locale from cookie 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Robust API over `localStorage` and `sessionStorage`.
 
 ### [`cookies`](./src/cookies.README.md)
 
-Get the content of a `cookie`.
+API over `document.cookies`.
 
 ### [`timeAgo`](./src/timeAgo.README.md)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   - [`loadScript`](#loadscript)
   - [`log`/`debug`](#logdebug)
   - [`storage`](#storage)
+  - [`cookies`](#cookies)
   - [`timeAgo`](#timeago)
 - [Installation](#installation)
   - [Bundling](#bundling)
@@ -55,6 +56,10 @@ Selectively log team-specific messages to the console.
 ### [`storage`](./src/storage.README.md)
 
 Robust API over `localStorage` and `sessionStorage`.
+
+### [`cookies`](./src/cookies.README.md)
+
+Get the content of a `cookie`.
 
 ### [`timeAgo`](./src/timeAgo.README.md)
 

--- a/src/cookies.README.md
+++ b/src/cookies.README.md
@@ -107,7 +107,7 @@ getCookie({name:'GU_geo_country'}); //GB
 getCookie({name:'GU_geo_country', shouldMemoize: true}); //GB
 ```
 
-## `removeCookie(name)`
+## `removeCookie({name, currentDomainOnly?})`
 
 Returns: `void`
 
@@ -119,8 +119,14 @@ Type: `string`
 
 Name of the stored cookie to remove.
 
+#### `currentDomainOnly`
+
+Type: `boolean`
+
+Set to true if it's a cookie for current domain only, defaults to false
 ### Example
 
 ```js
-removeCookie('GU_geo_country');
+removeCookie({name:'GU_geo_country'});
+removeCookie({name:'GU_geo_country', currentDomainOnly: true});
 ```

--- a/src/cookies.README.md
+++ b/src/cookies.README.md
@@ -15,9 +15,9 @@ import {
 
 ## Methods
 
--   [`setCookie(name, value, daysToLive, isCrossSubdomain, shouldMemoize)`](#setCookie)
+-   [`setCookie(name, value, daysToLive, isCrossSubdomain)`](#setCookie)
 -   [`setSessionCookie(name, value)`](#setSessionCookie)
--   [`getCookie(name)`](#getCookie)
+-   [`getCookie(name, shouldMemoize)`](#getCookie)
 -   [`removeCookie(name)`](#removeCookie)
 
 ## `setCookie`
@@ -50,12 +50,6 @@ Type: `boolean`<br>
 
 Set this true if the cookie is cross subdomain.
 
-#### `shouldMemoize?`
-
-Type: `boolean`<br>
-
-When this is set to true it will keep the cookie in memory to avoid fetching more than once.
-
 ### Example
 
 ```js
@@ -83,12 +77,6 @@ Type: `string`<br>
 
 Value of the cookie.
 
-#### `shouldMemoize?`
-
-Type: `boolean`<br>
-
-When this is set to true it will keep the cookie in memory to avoid fetching more than once.
-
 ### Example
 
 ```js
@@ -105,6 +93,13 @@ Returns: `cookie` value if it exists or `null`
 Type: `string`
 
 Name of the cookie to retrieve.
+
+
+#### `shouldMemoize?`
+
+Type: `boolean`<br>
+
+When this is set to true it will keep the cookie in memory to avoid fetching more than once.
 
 
 ### Example

--- a/src/cookies.README.md
+++ b/src/cookies.README.md
@@ -1,0 +1,13 @@
+# `getCookie(name)`
+
+Returns: `string` or `null`
+
+Returns the content of a cookie or `null` if the cookie does not exist.
+
+## Example
+
+```js
+import { getCookie } from '@guardian/libs';
+
+getCookie('GU_geo_country'); // 'GB'
+```

--- a/src/cookies.README.md
+++ b/src/cookies.README.md
@@ -15,12 +15,12 @@ import {
 
 ## Methods
 
--   [`setCookie(name, value, daysToLive, isCrossSubdomain)`](#setCookie)
+-   [`setCookie({name, value, daysToLive, isCrossSubdomain})`](#setCookie)
 -   [`setSessionCookie(name, value)`](#setSessionCookie)
 -   [`getCookie(name, shouldMemoize)`](#getCookie)
 -   [`removeCookie(name)`](#removeCookie)
 
-## `setCookie`
+## `setCookie({name, value, daysToLive?, isCrossSubdomain?})`
 
 Returns: `void`
 
@@ -53,13 +53,12 @@ Set this true if the cookie is cross subdomain.
 ### Example
 
 ```js
-setCookie('GU_country_code', 'GB')
-setCookie('GU_country_code', 'GB', 7)
-setCookie('GU_country_code', 'GB', 7, true)
-setCookie('GU_country_code', 'GB', 7, false, true)
+setCookie({name:'GU_country_code', value:'GB'})
+setCookie({name:'GU_country_code', value:'GB', daysToLive: 7})
+setCookie({name:'GU_country_code', value:'GB', daysToLive: 7, isCrossSubdomain: true})
 ```
 
-## `setSessionCookie`
+## `setSessionCookie(name, value)`
 
 Returns: `void`
 
@@ -84,7 +83,7 @@ setSessionCookie('GU_country_code', 'GB')
 setSessionCookie('GU_country_code', 'GB', true)
 ```
 
-## `getCookie`
+## `getCookie(name, shouldMemoize?)`
 
 Returns: `cookie` value if it exists or `null`
 
@@ -108,7 +107,7 @@ When this is set to true it will keep the cookie in memory to avoid fetching mor
 getCookie('GU_geo_country'); //GB
 ```
 
-## `removeCookie`
+## `removeCookie(name)`
 
 Returns: `void`
 

--- a/src/cookies.README.md
+++ b/src/cookies.README.md
@@ -2,18 +2,61 @@
 
 Robust API over `document.cookie`.
 
-### Example
+### Usage
 
 ```js
-import { cookies } from '@guardian/libs';
-
+import {
+    getCookie,
+    removeCookie,
+    setCookie,
+    setSessionCookie
+ } from '@guardian/libs';
 ```
 
 ## Methods
 
+-   [`setCookie(name, value, daysToLive, isCrossSubdomain)`](#setCookie)
 -   [`setSessionCookie(name, value)`](#setSessionCookie)
 -   [`getCookie(name)`](#getCookie)
--   [`cleanUp(names)`](#cleanUp)
+-   [`removeCookie(name)`](#removeCookie)
+
+## `setCookie`
+
+Returns: `void`
+
+Sets a cookie taking a name and value, optional daysToLive and optional isCrossSubdomain flag.
+
+#### `name`
+
+Type: `string`
+
+Name of the cookie.
+
+#### `value`
+
+Type: `string`<br>
+
+Value of the cookie.
+
+#### `daysToLive?`
+
+Type: `number`
+
+Days you would like this cookie to live for.
+
+#### `isCrossSubdomain?`
+
+Type: `boolean`<br>
+
+Set this true if the cookie is cross subdomain.
+
+### Example
+
+```js
+setSessionCookie('GU_country_code', 'GB')
+setSessionCookie('GU_country_code', 'GB', 7)
+setSessionCookie('GU_country_code', 'GB', 7, true)
+```
 
 ## `setSessionCookie`
 
@@ -56,20 +99,20 @@ Name of the cookie to retrieve.
 getCookie('GU_geo_country'); //GB
 ```
 
-## `cleanUp`
+## `removeCookie`
 
 Returns: `void`
 
-Removes a list of cookies.
+Removes a cookie.
 
-#### `[names]`
+#### `names`
 
-Type: `string[]`
+Type: `string`
 
-Names of the stored cookies to remove.
+Name of the stored cookie to remove.
 
 ### Example
 
 ```js
-cleanUp('GU_geo_country');
+removeCookie('GU_geo_country');
 ```

--- a/src/cookies.README.md
+++ b/src/cookies.README.md
@@ -16,15 +16,15 @@ import {
 ## Methods
 
 -   [`setCookie({name, value, daysToLive, isCrossSubdomain})`](#setCookie)
--   [`setSessionCookie(name, value)`](#setSessionCookie)
--   [`getCookie(name, shouldMemoize)`](#getCookie)
+-   [`setSessionCookie({name, value})`](#setSessionCookie)
+-   [`getCookie({name, shouldMemoize})`](#getCookie)
 -   [`removeCookie(name)`](#removeCookie)
 
 ## `setCookie({name, value, daysToLive?, isCrossSubdomain?})`
 
 Returns: `void`
 
-Sets a cookie taking a name and value, optional daysToLive and optional isCrossSubdomain flag.
+Sets a cookie taking a config object with name and value, optional daysToLive and optional isCrossSubdomain flag.
 
 #### `name`
 
@@ -58,11 +58,11 @@ setCookie({name:'GU_country_code', value:'GB', daysToLive: 7})
 setCookie({name:'GU_country_code', value:'GB', daysToLive: 7, isCrossSubdomain: true})
 ```
 
-## `setSessionCookie(name, value)`
+## `setSessionCookie({name, value})`
 
 Returns: `void`
 
-Sets a session cookie (no expiry date) taking a name and value.
+Sets a session cookie (no expiry date) taking a config object with name and value.
 
 #### `name`
 
@@ -79,13 +79,12 @@ Value of the cookie.
 ### Example
 
 ```js
-setSessionCookie('GU_country_code', 'GB')
-setSessionCookie('GU_country_code', 'GB', true)
+setSessionCookie({name:'GU_country_code', value: 'GB'})
 ```
 
-## `getCookie(name, shouldMemoize?)`
+## `getCookie({name, shouldMemoize?})`
 
-Returns: `cookie` value if it exists or `null`
+Returns: `cookie` value if it exists or `null`. Takes a config object with name and shouldMemoize params
 
 #### `name`
 
@@ -104,7 +103,8 @@ When this is set to true it will keep the cookie in memory to avoid fetching mor
 ### Example
 
 ```js
-getCookie('GU_geo_country'); //GB
+getCookie({name:'GU_geo_country'}); //GB
+getCookie({name:'GU_geo_country', shouldMemoize: true}); //GB
 ```
 
 ## `removeCookie(name)`

--- a/src/cookies.README.md
+++ b/src/cookies.README.md
@@ -15,7 +15,7 @@ import {
 
 ## Methods
 
--   [`setCookie(name, value, daysToLive, isCrossSubdomain)`](#setCookie)
+-   [`setCookie(name, value, daysToLive, isCrossSubdomain, shouldMemoize)`](#setCookie)
 -   [`setSessionCookie(name, value)`](#setSessionCookie)
 -   [`getCookie(name)`](#getCookie)
 -   [`removeCookie(name)`](#removeCookie)
@@ -50,12 +50,19 @@ Type: `boolean`<br>
 
 Set this true if the cookie is cross subdomain.
 
+#### `shouldMemoize?`
+
+Type: `boolean`<br>
+
+When this is set to true it will keep the cookie in memory to avoid fetching more than once.
+
 ### Example
 
 ```js
-setSessionCookie('GU_country_code', 'GB')
-setSessionCookie('GU_country_code', 'GB', 7)
-setSessionCookie('GU_country_code', 'GB', 7, true)
+setCookie('GU_country_code', 'GB')
+setCookie('GU_country_code', 'GB', 7)
+setCookie('GU_country_code', 'GB', 7, true)
+setCookie('GU_country_code', 'GB', 7, false, true)
 ```
 
 ## `setSessionCookie`
@@ -76,10 +83,17 @@ Type: `string`<br>
 
 Value of the cookie.
 
+#### `shouldMemoize?`
+
+Type: `boolean`<br>
+
+When this is set to true it will keep the cookie in memory to avoid fetching more than once.
+
 ### Example
 
 ```js
 setSessionCookie('GU_country_code', 'GB')
+setSessionCookie('GU_country_code', 'GB', true)
 ```
 
 ## `getCookie`

--- a/src/cookies.README.md
+++ b/src/cookies.README.md
@@ -23,7 +23,7 @@ Sets a session cookie (no expiry date) taking a name and value.
 
 #### `name`
 
-Type: `string`<br>
+Type: `string`
 
 Name of the cookie.
 
@@ -73,4 +73,3 @@ Names of the stored cookies to remove.
 ```js
 cleanUp('GU_geo_country');
 ```
-

--- a/src/cookies.README.md
+++ b/src/cookies.README.md
@@ -1,13 +1,76 @@
-# `getCookie(name)`
+# `cookies`
 
-Returns: `string` or `null`
+Robust API over `document.cookie`.
 
-Returns the content of a cookie or `null` if the cookie does not exist.
-
-## Example
+### Example
 
 ```js
-import { getCookie } from '@guardian/libs';
+import { cookies } from '@guardian/libs';
 
-getCookie('GU_geo_country'); // 'GB'
 ```
+
+## Methods
+
+-   [`setSessionCookie(name, value)`](#setSessionCookie)
+-   [`getCookie(name)`](#getCookie)
+-   [`cleanUp(names)`](#cleanUp)
+
+## `setSessionCookie`
+
+Returns: `void`
+
+Sets a session cookie (no expiry date) taking a name and value.
+
+#### `name`
+
+Type: `string`<br>
+
+Name of the cookie.
+
+#### `value`
+
+Type: `string`<br>
+
+Value of the cookie.
+
+### Example
+
+```js
+setSessionCookie('GU_country_code', 'GB')
+```
+
+## `getCookie`
+
+Returns: `cookie` value if it exists or `null`
+
+#### `name`
+
+Type: `string`
+
+Name of the cookie to retrieve.
+
+
+### Example
+
+```js
+getCookie('GU_geo_country'); //GB
+```
+
+## `cleanUp`
+
+Returns: `void`
+
+Removes a list of cookies.
+
+#### `[names]`
+
+Type: `string[]`
+
+Names of the stored cookies to remove.
+
+### Example
+
+```js
+cleanUp('GU_geo_country');
+```
+

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -44,6 +44,16 @@ describe('cookies', () => {
 		expect(getCookie('__qca')).toEqual('P0-938012256-1398171768649');
 	});
 
+	it('should be able to get a memoized cookie', () => {
+		setCookie('GU_geo_country', 'GB', 3, false, true);
+		expect(getCookie('GU_geo_country')).toEqual('GB');
+	});
+
+	it('should be able to get a memoized session cookie', () => {
+		setSessionCookie('GU_geo_country', 'IT', true);
+		expect(getCookie('GU_geo_country')).toEqual('IT');
+	});
+
 	it('should be able to set a cookie', () => {
 		expect(document.cookie).toEqual('');
 		setCookie('cookie-1-name', 'cookie-1-value');

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -36,7 +36,7 @@ describe('cookies', () => {
 	it('should be able to get a cookie', () => {
 		document.cookie =
 			'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649;';
-		expect(cookies.getCookie('__qca')).toEqual(
+		expect(cookies.getCookie({ name: '__qca' })).toEqual(
 			'P0-938012256-1398171768649',
 		);
 	});
@@ -68,7 +68,10 @@ describe('cookies', () => {
 
 	it('should be able to set a session cookie', () => {
 		expect(document.cookie).toEqual('');
-		cookies.setSessionCookie('cookie-1-name', 'cookie-1-value');
+		cookies.setSessionCookie({
+			name: 'cookie-1-name',
+			value: 'cookie-1-value',
+		});
 		expect(document.cookie).toEqual(
 			'cookie-1-name=cookie-1-value; path=/; domain=.theguardian.com',
 		);
@@ -82,11 +85,21 @@ describe('cookies', () => {
 			isCrossSubdomain: true,
 		});
 		const spy = jest.spyOn(cookies, 'getCookieValues');
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('GB');
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('GB');
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('GB');
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('GB');
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('GB');
 		// for some reason the spy is been called 1 additional time although that's not happening in reality
 		expect(spy).not.toHaveBeenCalledTimes(2);
 	});
@@ -98,9 +111,15 @@ describe('cookies', () => {
 			daysToLive: 1,
 		});
 		const spy = jest.spyOn(cookies, 'getCookieValues');
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('IT');
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('IT');
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('IT');
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('IT');
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('IT');
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('IT');
 		// for some reason the spy is been called 1 additional time although that's not happening in reality
 		expect(spy).not.toHaveBeenCalledTimes(2);
 	});
@@ -112,21 +131,29 @@ describe('cookies', () => {
 			daysToLive: 3,
 			isCrossSubdomain: false,
 		});
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('GB');
 		cookies.setCookie({
 			name: 'GU_geo_country',
 			value: 'IT',
 			daysToLive: 3,
 			isCrossSubdomain: false,
 		});
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('IT');
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('IT');
 	});
 
 	it('should be able to re-set a memoized session cookie', () => {
-		cookies.setSessionCookie('GU_geo_country', 'GB');
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
-		cookies.setSessionCookie('GU_geo_country', 'GR');
-		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GR');
+		cookies.setSessionCookie({ name: 'GU_geo_country', value: 'GB' });
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('GB');
+		cookies.setSessionCookie({ name: 'GU_geo_country', value: 'GR' });
+		expect(
+			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
+		).toEqual('GR');
 	});
 
 	it('should be able the remove a cookie', () => {

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -159,7 +159,7 @@ describe('cookies', () => {
 	it('should be able the remove a cookie', () => {
 		document.cookie = 'cookie-1-name=cookie-1-value';
 
-		cookies.removeCookie('cookie-1-name');
+		cookies.removeCookie({ name: 'cookie-1-name' });
 
 		const { cookie } = document;
 

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -1,12 +1,5 @@
 import MockDate from 'mockdate';
-import {
-	getCookie,
-	getCookieValues,
-	removeCookie,
-	setCookie,
-	setSessionCookie,
-} from './cookies';
-import * as cookies from "./cookies";
+import * as cookies from './cookies';
 
 describe('cookies', () => {
 	beforeAll(() => {
@@ -43,38 +36,17 @@ describe('cookies', () => {
 	it('should be able to get a cookie', () => {
 		document.cookie =
 			'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649;';
-		expect(getCookie('__qca')).toEqual('P0-938012256-1398171768649');
-	});
-
-	it('should be able to get a memoized cookie', () => {
-		setCookie('GU_geo_country', 'GB', 3, false);
-		const spy = jest.spyOn(cookies, 'getCookieValues');
-		expect(getCookie('GU_geo_country', true)).toEqual('GB');
-		expect(getCookie('GU_geo_country', true)).toEqual('GB');
-		expect(getCookie('GU_geo_country', true)).toEqual('GB');
-		expect(getCookie('GU_geo_country', true)).toEqual('GB');
-		expect(getCookie('GU_geo_country', true)).toEqual('GB');
-		// for some reason the spy is been called 1 additional time although that's not happening in reality
-		expect(spy).not.toHaveBeenCalledTimes(2);
-	});
-
-	it('should be able to re-set a memoized cookie', () => {
-		setCookie('GU_geo_country', 'GB', 3, false);
-		expect(getCookie('GU_geo_country', true)).toEqual('GB');
-		setCookie('GU_geo_country', 'IT', 3, false);
-		expect(getCookie('GU_geo_country', true)).toEqual('IT');
-	});
-
-	it('should be able to re-set a memoized session cookie', () => {
-		setSessionCookie('GU_geo_country', 'GB');
-		expect(getCookie('GU_geo_country', true)).toEqual('GB');
-		setSessionCookie('GU_geo_country', 'GR');
-		expect(getCookie('GU_geo_country', true)).toEqual('GR');
+		expect(cookies.getCookie('__qca')).toEqual(
+			'P0-938012256-1398171768649',
+		);
 	});
 
 	it('should be able to set a cookie', () => {
 		expect(document.cookie).toEqual('');
-		setCookie('cookie-1-name', 'cookie-1-value');
+		cookies.setCookie({
+			name: 'cookie-1-name',
+			value: 'cookie-1-value',
+		});
 		expect(document.cookie).toMatch(
 			new RegExp(
 				'cookie-1-name=cookie-1-value; path=/; expires=Wed, 01 Apr 2020 12:00:00 GMT; domain=.theguardian.com',
@@ -84,7 +56,11 @@ describe('cookies', () => {
 
 	it('should be able to set a cookie for a specific number of days', () => {
 		expect(document.cookie).toEqual('');
-		setCookie('cookie-1-name', 'cookie-1-value', 7);
+		cookies.setCookie({
+			name: 'cookie-1-name',
+			value: 'cookie-1-value',
+			daysToLive: 7,
+		});
 		expect(document.cookie).toEqual(
 			'cookie-1-name=cookie-1-value; path=/; expires=Sun, 24 Nov 2019 12:00:00 GMT; domain=.theguardian.com',
 		);
@@ -92,16 +68,71 @@ describe('cookies', () => {
 
 	it('should be able to set a session cookie', () => {
 		expect(document.cookie).toEqual('');
-		setSessionCookie('cookie-1-name', 'cookie-1-value');
+		cookies.setSessionCookie('cookie-1-name', 'cookie-1-value');
 		expect(document.cookie).toEqual(
 			'cookie-1-name=cookie-1-value; path=/; domain=.theguardian.com',
 		);
 	});
 
+	it('should be able to get a memoized cookie with days to live and cross subdomain', () => {
+		cookies.setCookie({
+			name: 'GU_geo_country',
+			value: 'GB',
+			daysToLive: 1,
+			isCrossSubdomain: true,
+		});
+		const spy = jest.spyOn(cookies, 'getCookieValues');
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
+		// for some reason the spy is been called 1 additional time although that's not happening in reality
+		expect(spy).not.toHaveBeenCalledTimes(2);
+	});
+
+	it('should be able to get a memoized cookie with days to live', () => {
+		cookies.setCookie({
+			name: 'GU_geo_country',
+			value: 'IT',
+			daysToLive: 1,
+		});
+		const spy = jest.spyOn(cookies, 'getCookieValues');
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('IT');
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('IT');
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('IT');
+		// for some reason the spy is been called 1 additional time although that's not happening in reality
+		expect(spy).not.toHaveBeenCalledTimes(2);
+	});
+
+	it('should be able to re-set a memoized cookie', () => {
+		cookies.setCookie({
+			name: 'GU_geo_country',
+			value: 'GB',
+			daysToLive: 3,
+			isCrossSubdomain: false,
+		});
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
+		cookies.setCookie({
+			name: 'GU_geo_country',
+			value: 'IT',
+			daysToLive: 3,
+			isCrossSubdomain: false,
+		});
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('IT');
+	});
+
+	it('should be able to re-set a memoized session cookie', () => {
+		cookies.setSessionCookie('GU_geo_country', 'GB');
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GB');
+		cookies.setSessionCookie('GU_geo_country', 'GR');
+		expect(cookies.getCookie('GU_geo_country', true)).toEqual('GR');
+	});
+
 	it('should be able the remove a cookie', () => {
 		document.cookie = 'cookie-1-name=cookie-1-value';
 
-		removeCookie('cookie-1-name');
+		cookies.removeCookie('cookie-1-name');
 
 		const { cookie } = document;
 

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -91,17 +91,7 @@ describe('cookies', () => {
 		expect(
 			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
 		).toEqual('GB');
-		expect(
-			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
-		).toEqual('GB');
-		expect(
-			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
-		).toEqual('GB');
-		expect(
-			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
-		).toEqual('GB');
-		// for some reason the spy is been called 1 additional time although that's not happening in reality
-		expect(spy).not.toHaveBeenCalledTimes(2);
+		expect(spy).toHaveBeenCalledTimes(1);
 	});
 
 	it('should be able to get a memoized cookie with days to live', () => {

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -1,10 +1,12 @@
 import MockDate from 'mockdate';
 import {
 	getCookie,
+	getCookieValues,
 	removeCookie,
 	setCookie,
 	setSessionCookie,
 } from './cookies';
+import * as cookies from "./cookies";
 
 describe('cookies', () => {
 	beforeAll(() => {
@@ -45,13 +47,29 @@ describe('cookies', () => {
 	});
 
 	it('should be able to get a memoized cookie', () => {
-		setCookie('GU_geo_country', 'GB', 3, false, true);
-		expect(getCookie('GU_geo_country')).toEqual('GB');
+		setCookie('GU_geo_country', 'GB', 3, false);
+		const spy = jest.spyOn(cookies, 'getCookieValues');
+		expect(getCookie('GU_geo_country', true)).toEqual('GB');
+		expect(getCookie('GU_geo_country', true)).toEqual('GB');
+		expect(getCookie('GU_geo_country', true)).toEqual('GB');
+		expect(getCookie('GU_geo_country', true)).toEqual('GB');
+		expect(getCookie('GU_geo_country', true)).toEqual('GB');
+		// for some reason the spy is been called 1 additional time although that's not happening in reality
+		expect(spy).not.toHaveBeenCalledTimes(2);
 	});
 
-	it('should be able to get a memoized session cookie', () => {
-		setSessionCookie('GU_geo_country', 'IT', true);
-		expect(getCookie('GU_geo_country')).toEqual('IT');
+	it('should be able to re-set a memoized cookie', () => {
+		setCookie('GU_geo_country', 'GB', 3, false);
+		expect(getCookie('GU_geo_country', true)).toEqual('GB');
+		setCookie('GU_geo_country', 'IT', 3, false);
+		expect(getCookie('GU_geo_country', true)).toEqual('IT');
+	});
+
+	it('should be able to re-set a memoized session cookie', () => {
+		setSessionCookie('GU_geo_country', 'GB');
+		expect(getCookie('GU_geo_country', true)).toEqual('GB');
+		setSessionCookie('GU_geo_country', 'GR');
+		expect(getCookie('GU_geo_country', true)).toEqual('GR');
 	});
 
 	it('should be able to set a cookie', () => {

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -1,6 +1,6 @@
-import { getCookie } from './cookies';
+import { cleanUp, getCookie, setSessionCookie } from './cookies';
 
-describe('getCookie', () => {
+describe('cookies', () => {
 	let cookieValue = '';
 
 	Object.defineProperty(document, 'domain', { value: 'www.theguardian.com' });
@@ -29,6 +29,39 @@ describe('getCookie', () => {
 			'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649; __gads=ID=85aa476fff43818a:T=1398171769:S=ALNI_MbfMkJmvVDwlqDMvJk1oCBV3jNUoA; noticebar_cookie=2; GU_mvt_id=717659; fsr.r=%7B%22d%22%3A90%2C%22i%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22e%22%3A1416223264445%7D; _ga=GA1.2.555908995.1398171761; QSI_HistorySession=http%3A%2F%2Fwww.theguardian.com%2Fworld%2F2014%2Fnov%2F11%2Findian-women-die-mass-steri…ov%2F11%2Fputin-gallant-gesture-chinese-leader-wife-censored~1415796988465; mlUserID=amIIKWa5S6ha; _em_vt=eed0af5afb2b123c5293cbae36c953ec8ab6445d73-180037745475ec3b; GU_EDITION=UK; GU_MI=mi_i%3D13552794%3Bmi_p%3DCRE%2CRCO%3Bgu_pk%3DCRE%2CRCO%3Bmi_e%3D%21201412141140%3Bmi_dn%3DJohn+Duffell%3Bmi_s%3Da7dd96e91fffd189215abaa69107bf13; GU_U=WyIxMzU1Mjc5NCIsImpvaG4uZHVmZmVsbEBndWFyZGlhbi5jby51ayIsIkpvaG4gRHVmZmVsbCIsIjIiLDE0MjQ5NTA4NDgwMDEsMSwxNDA1OTUxMDgyMDAwLHRydWVd.MCwCFErJFuSa3ptSv2V6JYkIjTtTFUKiAhQDLOlsFAulk4mg7yj8DWswB3p_1Q; _cb_ls=1; s_campaign=twt_gu; _chartbeat2=CbF00iBuBN28SPnnY.1417174852129.1417516877697.10001; fsr.s=%7B%22v2%22%3A-2%2C%22v1%22%3A1%2C%22rid%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22ru%22%3A%22http%3A%2F%2Fwww.theguardian.com%2Fuk%22%2C%22r%22%3A%22www.theguardian.com%22%2C%22st%2…22Y%22%7D%2C%22l%22%3A%22en%22%2C%22i%22%3A-1%2C%22f%22%3A1417516902586%7D; fsr.a=1417516904960; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_nr%3D1413290266538-Repeat%7C1444826266538%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; OAX=X5GDnlPairgACdD1; optimizelySegments=%7B%22172123993%22%3A%22none%22%2C%22172180831%22%3A%22none%22%2C%22172233718%22%3A%22false%22%2C%22172284779%22%3A%22gc%22%2C%22172321425%22%3A%22false%22%2C%22172361369%22%3A%22referral%22%2C%22172368238%22%3A%22search%22%2C%22172387121%22%3A%22gc%22%2C%22280150302%22%3A%22gc%22%2C%22280266488%22%3A%22false%22%2C%22280820196%22%3A%22none%22%2C%22280923576%22%3A%22referral%22%2C%22290314994%22%3A%22false%22%2C%22290553915%22%3A%22direct%22%2C%22293452255%22%3A%22gc%22%2C%22293462044%22%3A%22none%22%2C%22812091703%22%3A%22true%22%2C%22813360577%22%3A%22true%22%2C%221214390054%22%3A%22true%22%2C%221992100896%22%3A%22false%22%2C%222001830212%22%3A%22none%22%2C%222004900216%22%3A%22referral%22%2C%222005870214%22%3A%22gc%22%7D; optimizelyBuckets=%7B%7D; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B%20s_nr%3D1417605906076-Repeat%7C1449141906076%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; s_sq=%5B%5BB%5D%5D; GU_VIEW=responsive; s_cc=true; bwid=kvdn_943h8SSC6h3R5hyJ31g; s_fid=470C3252CA9A4650-35C6B54A21985FBA; s_daily_habit=16406%2C16407%2C16408; s_lv=1417705099834; s_nr=1417705099835-Repeat; s_vi=[CS]v1|29AB343C05013259-4000014980021C3D[CE]; cto2_guardian=';
 		expect(getCookie('s_vi')).toEqual(
 			'[CS]v1|29AB343C05013259-4000014980021C3D[CE]',
+		);
+	});
+
+	it('should be able to get country cookie', () => {
+		document.cookie = 'GU_geo_country=GB;';
+		expect(getCookie('GU_geo_country')).toEqual('GB');
+	});
+
+	it('should be able to set a session cookie', () => {
+		setSessionCookie('cookie-1-name', 'cookie-1-value');
+		expect(document.cookie).toEqual(
+			'cookie-1-name=cookie-1-value; path=/; domain=.theguardian.com',
+		);
+	});
+
+	it('should be able the clean a list of cookies', () => {
+		document.cookie = 'cookie-1-name=cookie-1-value';
+		document.cookie = 'cookie-2-name=cookie-2-value';
+		document.cookie = 'cookie-3-name=cookie-3-value';
+
+		cleanUp(['cookie-1-name', 'cookie-2-name']);
+
+		const { cookie } = document;
+
+		expect(cookie).toMatch(
+			new RegExp(
+				'cookie-1-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.theguardian.com',
+			),
+		);
+		expect(cookie).toMatch(
+			new RegExp(
+				'cookie-2-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.theguardian.com',
+			),
 		);
 	});
 });

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -1,6 +1,20 @@
-import { cleanUp, getCookie, setSessionCookie } from './cookies';
+import MockDate from 'mockdate';
+import {
+	getCookie,
+	removeCookie,
+	setCookie,
+	setSessionCookie,
+} from './cookies';
 
 describe('cookies', () => {
+	beforeAll(() => {
+		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
+	});
+
+	afterAll(() => {
+		MockDate.reset();
+	});
+
 	let cookieValue = '';
 
 	Object.defineProperty(document, 'domain', { value: 'www.theguardian.com' });
@@ -26,41 +40,46 @@ describe('cookies', () => {
 
 	it('should be able to get a cookie', () => {
 		document.cookie =
-			'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649; __gads=ID=85aa476fff43818a:T=1398171769:S=ALNI_MbfMkJmvVDwlqDMvJk1oCBV3jNUoA; noticebar_cookie=2; GU_mvt_id=717659; fsr.r=%7B%22d%22%3A90%2C%22i%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22e%22%3A1416223264445%7D; _ga=GA1.2.555908995.1398171761; QSI_HistorySession=http%3A%2F%2Fwww.theguardian.com%2Fworld%2F2014%2Fnov%2F11%2Findian-women-die-mass-steri…ov%2F11%2Fputin-gallant-gesture-chinese-leader-wife-censored~1415796988465; mlUserID=amIIKWa5S6ha; _em_vt=eed0af5afb2b123c5293cbae36c953ec8ab6445d73-180037745475ec3b; GU_EDITION=UK; GU_MI=mi_i%3D13552794%3Bmi_p%3DCRE%2CRCO%3Bgu_pk%3DCRE%2CRCO%3Bmi_e%3D%21201412141140%3Bmi_dn%3DJohn+Duffell%3Bmi_s%3Da7dd96e91fffd189215abaa69107bf13; GU_U=WyIxMzU1Mjc5NCIsImpvaG4uZHVmZmVsbEBndWFyZGlhbi5jby51ayIsIkpvaG4gRHVmZmVsbCIsIjIiLDE0MjQ5NTA4NDgwMDEsMSwxNDA1OTUxMDgyMDAwLHRydWVd.MCwCFErJFuSa3ptSv2V6JYkIjTtTFUKiAhQDLOlsFAulk4mg7yj8DWswB3p_1Q; _cb_ls=1; s_campaign=twt_gu; _chartbeat2=CbF00iBuBN28SPnnY.1417174852129.1417516877697.10001; fsr.s=%7B%22v2%22%3A-2%2C%22v1%22%3A1%2C%22rid%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22ru%22%3A%22http%3A%2F%2Fwww.theguardian.com%2Fuk%22%2C%22r%22%3A%22www.theguardian.com%22%2C%22st%2…22Y%22%7D%2C%22l%22%3A%22en%22%2C%22i%22%3A-1%2C%22f%22%3A1417516902586%7D; fsr.a=1417516904960; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_nr%3D1413290266538-Repeat%7C1444826266538%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; OAX=X5GDnlPairgACdD1; optimizelySegments=%7B%22172123993%22%3A%22none%22%2C%22172180831%22%3A%22none%22%2C%22172233718%22%3A%22false%22%2C%22172284779%22%3A%22gc%22%2C%22172321425%22%3A%22false%22%2C%22172361369%22%3A%22referral%22%2C%22172368238%22%3A%22search%22%2C%22172387121%22%3A%22gc%22%2C%22280150302%22%3A%22gc%22%2C%22280266488%22%3A%22false%22%2C%22280820196%22%3A%22none%22%2C%22280923576%22%3A%22referral%22%2C%22290314994%22%3A%22false%22%2C%22290553915%22%3A%22direct%22%2C%22293452255%22%3A%22gc%22%2C%22293462044%22%3A%22none%22%2C%22812091703%22%3A%22true%22%2C%22813360577%22%3A%22true%22%2C%221214390054%22%3A%22true%22%2C%221992100896%22%3A%22false%22%2C%222001830212%22%3A%22none%22%2C%222004900216%22%3A%22referral%22%2C%222005870214%22%3A%22gc%22%7D; optimizelyBuckets=%7B%7D; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B%20s_nr%3D1417605906076-Repeat%7C1449141906076%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; s_sq=%5B%5BB%5D%5D; GU_VIEW=responsive; s_cc=true; bwid=kvdn_943h8SSC6h3R5hyJ31g; s_fid=470C3252CA9A4650-35C6B54A21985FBA; s_daily_habit=16406%2C16407%2C16408; s_lv=1417705099834; s_nr=1417705099835-Repeat; s_vi=[CS]v1|29AB343C05013259-4000014980021C3D[CE]; cto2_guardian=';
-		expect(getCookie('s_vi')).toEqual(
-			'[CS]v1|29AB343C05013259-4000014980021C3D[CE]',
+			'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649;';
+		expect(getCookie('__qca')).toEqual('P0-938012256-1398171768649');
+	});
+
+	it('should be able to set a cookie', () => {
+		expect(document.cookie).toEqual('');
+		setCookie('cookie-1-name', 'cookie-1-value');
+		expect(document.cookie).toMatch(
+			new RegExp(
+				'cookie-1-name=cookie-1-value; path=/; expires=Wed, 01 Apr 2020 12:00:00 GMT; domain=.theguardian.com',
+			),
 		);
 	});
 
-	it('should be able to get country cookie', () => {
-		document.cookie = 'GU_geo_country=GB;';
-		expect(getCookie('GU_geo_country')).toEqual('GB');
+	it('should be able to set a cookie for a specific number of days', () => {
+		expect(document.cookie).toEqual('');
+		setCookie('cookie-1-name', 'cookie-1-value', 7);
+		expect(document.cookie).toEqual(
+			'cookie-1-name=cookie-1-value; path=/; expires=Sun, 24 Nov 2019 12:00:00 GMT; domain=.theguardian.com',
+		);
 	});
 
 	it('should be able to set a session cookie', () => {
+		expect(document.cookie).toEqual('');
 		setSessionCookie('cookie-1-name', 'cookie-1-value');
 		expect(document.cookie).toEqual(
 			'cookie-1-name=cookie-1-value; path=/; domain=.theguardian.com',
 		);
 	});
 
-	it('should be able the clean a list of cookies', () => {
+	it('should be able the remove a cookie', () => {
 		document.cookie = 'cookie-1-name=cookie-1-value';
-		document.cookie = 'cookie-2-name=cookie-2-value';
-		document.cookie = 'cookie-3-name=cookie-3-value';
 
-		cleanUp(['cookie-1-name', 'cookie-2-name']);
+		removeCookie('cookie-1-name');
 
 		const { cookie } = document;
 
 		expect(cookie).toMatch(
 			new RegExp(
 				'cookie-1-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.theguardian.com',
-			),
-		);
-		expect(cookie).toMatch(
-			new RegExp(
-				'cookie-2-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.theguardian.com',
 			),
 		);
 	});

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -1,0 +1,34 @@
+import { getCookie } from './cookies';
+
+describe('getCookie', () => {
+	let cookieValue = '';
+
+	Object.defineProperty(document, 'domain', { value: 'www.theguardian.com' });
+	Object.defineProperty(document, 'cookie', {
+		get() {
+			return cookieValue.replace('|', ';').replace(/^[;|]|[;|]$/g, '');
+		},
+
+		set(value: string) {
+			const name = value.split('=')[0];
+			const newVal = cookieValue
+				.split('|')
+				.filter((cookie) => cookie.split('=')[0] !== name);
+
+			newVal.push(value);
+			cookieValue = newVal.join('|');
+		},
+	});
+
+	beforeEach(() => {
+		cookieValue = '';
+	});
+
+	it('should be able to get a cookie', () => {
+		document.cookie =
+			'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649; __gads=ID=85aa476fff43818a:T=1398171769:S=ALNI_MbfMkJmvVDwlqDMvJk1oCBV3jNUoA; noticebar_cookie=2; GU_mvt_id=717659; fsr.r=%7B%22d%22%3A90%2C%22i%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22e%22%3A1416223264445%7D; _ga=GA1.2.555908995.1398171761; QSI_HistorySession=http%3A%2F%2Fwww.theguardian.com%2Fworld%2F2014%2Fnov%2F11%2Findian-women-die-mass-steri…ov%2F11%2Fputin-gallant-gesture-chinese-leader-wife-censored~1415796988465; mlUserID=amIIKWa5S6ha; _em_vt=eed0af5afb2b123c5293cbae36c953ec8ab6445d73-180037745475ec3b; GU_EDITION=UK; GU_MI=mi_i%3D13552794%3Bmi_p%3DCRE%2CRCO%3Bgu_pk%3DCRE%2CRCO%3Bmi_e%3D%21201412141140%3Bmi_dn%3DJohn+Duffell%3Bmi_s%3Da7dd96e91fffd189215abaa69107bf13; GU_U=WyIxMzU1Mjc5NCIsImpvaG4uZHVmZmVsbEBndWFyZGlhbi5jby51ayIsIkpvaG4gRHVmZmVsbCIsIjIiLDE0MjQ5NTA4NDgwMDEsMSwxNDA1OTUxMDgyMDAwLHRydWVd.MCwCFErJFuSa3ptSv2V6JYkIjTtTFUKiAhQDLOlsFAulk4mg7yj8DWswB3p_1Q; _cb_ls=1; s_campaign=twt_gu; _chartbeat2=CbF00iBuBN28SPnnY.1417174852129.1417516877697.10001; fsr.s=%7B%22v2%22%3A-2%2C%22v1%22%3A1%2C%22rid%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22ru%22%3A%22http%3A%2F%2Fwww.theguardian.com%2Fuk%22%2C%22r%22%3A%22www.theguardian.com%22%2C%22st%2…22Y%22%7D%2C%22l%22%3A%22en%22%2C%22i%22%3A-1%2C%22f%22%3A1417516902586%7D; fsr.a=1417516904960; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_nr%3D1413290266538-Repeat%7C1444826266538%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; OAX=X5GDnlPairgACdD1; optimizelySegments=%7B%22172123993%22%3A%22none%22%2C%22172180831%22%3A%22none%22%2C%22172233718%22%3A%22false%22%2C%22172284779%22%3A%22gc%22%2C%22172321425%22%3A%22false%22%2C%22172361369%22%3A%22referral%22%2C%22172368238%22%3A%22search%22%2C%22172387121%22%3A%22gc%22%2C%22280150302%22%3A%22gc%22%2C%22280266488%22%3A%22false%22%2C%22280820196%22%3A%22none%22%2C%22280923576%22%3A%22referral%22%2C%22290314994%22%3A%22false%22%2C%22290553915%22%3A%22direct%22%2C%22293452255%22%3A%22gc%22%2C%22293462044%22%3A%22none%22%2C%22812091703%22%3A%22true%22%2C%22813360577%22%3A%22true%22%2C%221214390054%22%3A%22true%22%2C%221992100896%22%3A%22false%22%2C%222001830212%22%3A%22none%22%2C%222004900216%22%3A%22referral%22%2C%222005870214%22%3A%22gc%22%7D; optimizelyBuckets=%7B%7D; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B%20s_nr%3D1417605906076-Repeat%7C1449141906076%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; s_sq=%5B%5BB%5D%5D; GU_VIEW=responsive; s_cc=true; bwid=kvdn_943h8SSC6h3R5hyJ31g; s_fid=470C3252CA9A4650-35C6B54A21985FBA; s_daily_habit=16406%2C16407%2C16408; s_lv=1417705099834; s_nr=1417705099835-Repeat; s_vi=[CS]v1|29AB343C05013259-4000014980021C3D[CE]; cto2_guardian=';
+		expect(getCookie('s_vi')).toEqual(
+			'[CS]v1|29AB343C05013259-4000014980021C3D[CE]',
+		);
+	});
+});

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -108,7 +108,19 @@ export const setSessionCookie = ({
 	}
 };
 
-export const removeCookie = (name: string, currentDomainOnly = false): void => {
+/**
+ * Removes a cookie.
+ * @param details Details about the cookie.
+ * @param details.name - the cookie’s name.
+ * @param details.currentDomainOnly - set to true if it's only for current domain
+ */
+export const removeCookie = ({
+	name,
+	currentDomainOnly = false,
+}: {
+	name: string;
+	currentDomainOnly?: boolean;
+}): void => {
 	const expires = 'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
 	const path = 'path=/;';
 

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -14,6 +14,49 @@ const getCookieValues = (name: string) => {
 	}, []);
 };
 
+// subset of https://github.com/guzzle/guzzle/pull/1131
+const isValidCookieValue = (name: string) =>
+	!/[()<>@,;"\\/[\]?={} \t]/g.test(name);
+
+const getShortDomain = ({ isCrossSubdomain = false } = {}) => {
+	const domain = document.domain || '';
+
+	if (domain === 'localhost' || window.guardian?.config?.page?.isPreview) {
+		return domain;
+	}
+
+	// Trim any possible subdomain (will be shared with supporter, identity, etc)
+	if (isCrossSubdomain) {
+		return ['', ...domain.split('.').slice(-2)].join('.');
+	}
+	// Trim subdomains for prod (www.theguardian), code (m.code.dev-theguardian) and dev (dev.theguardian, m.thegulocal)
+	return domain.replace(/^(www|m\.code|dev|m)\./, '.');
+};
+
+const getDomainAttribute = ({ isCrossSubdomain = false } = {}) => {
+	const shortDomain = getShortDomain({ isCrossSubdomain });
+	return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
+};
+
+const removeCookie = (name: string, currentDomainOnly = false): void => {
+	const expires = 'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+	const path = 'path=/;';
+
+	// Remove cookie, implicitly using the document's domain.
+	document.cookie = `${name}=;${path}${expires}`;
+	if (!currentDomainOnly) {
+		// also remove from the short domain
+		document.cookie = `${name}=;${path}${expires} domain=${getShortDomain()};`;
+	}
+};
+
+export const setSessionCookie = (name: string, value: string): void => {
+	if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
+		return;
+	}
+	document.cookie = `${name}=${value}; path=/;${getDomainAttribute()}`;
+};
+
 export const getCookie = (name: string): string | null => {
 	const cookieVal = getCookieValues(name);
 
@@ -21,4 +64,10 @@ export const getCookie = (name: string): string | null => {
 		return cookieVal[0];
 	}
 	return null;
+};
+
+export const cleanUp = (names: string[]): void => {
+	names.forEach((name) => {
+		removeCookie(name);
+	});
 };

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -42,10 +42,11 @@ const getDomainAttribute = ({ isCrossSubdomain = false } = {}) => {
 
 /**
  * Set a cookie. If it's been memoized it will replace it's memoized value
- * @param {string} name - the cookie’s name.
- * @param {string} value - the cookie’s value.
- * @param {number} daysToLive - expiry date will be calculated mased on the daysToLive
- * @param {boolean} isCrossSubdomain - specify if it's a cross subdomain cookie, default false
+ * @param details Details about the cookie.
+ * @param details.name - the cookie’s name.
+ * @param details.value - the cookie’s value.
+ * @param details.daysToLive - optional expiry date will be calculated based on the daysToLive
+ * @param details.isCrossSubdomain - specify if it's a cross subdomain cookie, default false
  */
 export const setCookie = ({
 	name,
@@ -85,10 +86,17 @@ export const setCookie = ({
 
 /**
  * Set a session cookie. If it's been memoized it will replace memoized value
- * @param {string} name - the cookie’s name.
- * @param {string} value - the cookie’s value.
+ * @param details Details about the cookie.
+ * @param details.name - the cookie’s name.
+ * @param details.value - the cookie’s value.
  */
-export const setSessionCookie = (name: string, value: string): void => {
+export const setSessionCookie = ({
+	name,
+	value,
+}: {
+	name: string;
+	value: string;
+}): void => {
 	if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
 		return;
 	}
@@ -114,13 +122,17 @@ export const removeCookie = (name: string, currentDomainOnly = false): void => {
 
 /**
  * Return a cookie. If it's been memoized it won't retrieve it again.
- * @param {string} name - the cookie’s name.
- * @param {boolean} shouldMemoize - set to true if you want to memoize it, default false.
+ * @param details Details about the cookie.
+ * @param details.name - the cookie’s name.
+ * @param details.shouldMemoize - set to true if you want to memoize it, default false.
  */
-export const getCookie = (
-	name: string,
+export const getCookie = ({
+	name,
 	shouldMemoize = false,
-): string | null => {
+}: {
+	name: string;
+	shouldMemoize?: boolean;
+}): string | null => {
 	if (memoizedCookies.has(name)) {
 		return memoizedCookies.get(name) ?? null;
 	}

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,5 +1,5 @@
 const memoizedCookies: Map<string, string> = new Map<string, string>();
-const VALID_COOKIE_REGEX = /[()<>@,;"\\/[\]?={} \t]/g;
+const COOKIE_REGEX = /[()<>@,;"\\/[\]?={} \t]/g;
 
 export const getCookieValues = (name: string): string[] => {
 	const nameEq = `${name}=`;
@@ -18,7 +18,7 @@ export const getCookieValues = (name: string): string[] => {
 };
 
 // subset of https://github.com/guzzle/guzzle/pull/1131
-const isValidCookieValue = (name: string) => !VALID_COOKIE_REGEX.test(name);
+const isValidCookieValue = (name: string) => !COOKIE_REGEX.test(name);
 
 const getShortDomain = ({ isCrossSubdomain = false } = {}) => {
 	const domain = document.domain || '';

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,6 +1,6 @@
 const memoizedCookies: Map<string, string> = new Map<string, string>();
 
-export const getCookieValues = (name: string) => {
+export const getCookieValues = (name: string): string[] => {
 	const nameEq = `${name}=`;
 	const cookies = document.cookie.split(';');
 
@@ -41,18 +41,23 @@ const getDomainAttribute = ({ isCrossSubdomain = false } = {}) => {
 };
 
 /**
- * Set a cookie. If it's been memoized it won't retrieve it again.
+ * Set a cookie. If it's been memoized it will replace it's memoized value
  * @param {string} name - the cookie’s name.
  * @param {string} value - the cookie’s value.
  * @param {number} daysToLive - expiry date will be calculated mased on the daysToLive
  * @param {boolean} isCrossSubdomain - specify if it's a cross subdomain cookie, default false
  */
-export const setCookie = (
-	name: string,
-	value: string,
-	daysToLive?: number,
+export const setCookie = ({
+	name,
+	value,
+	daysToLive,
 	isCrossSubdomain = false,
-): void => {
+}: {
+	name: string;
+	value: string;
+	daysToLive?: number;
+	isCrossSubdomain?: boolean;
+}): void => {
 	const expires = new Date();
 
 	if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
@@ -79,7 +84,7 @@ export const setCookie = (
 };
 
 /**
- * Set a session cookieookie. If it's been memoized it won't retrieve it again.
+ * Set a session cookie. If it's been memoized it will replace memoized value
  * @param {string} name - the cookie’s name.
  * @param {string} value - the cookie’s value.
  */

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -38,7 +38,40 @@ const getDomainAttribute = ({ isCrossSubdomain = false } = {}) => {
 	return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
 };
 
-const removeCookie = (name: string, currentDomainOnly = false): void => {
+export const setCookie = (
+	name: string,
+	value: string,
+	daysToLive?: number,
+	isCrossSubdomain = false,
+): void => {
+	const expires = new Date();
+
+	if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
+		return;
+	}
+
+	if (daysToLive) {
+		expires.setDate(expires.getDate() + daysToLive);
+	} else {
+		expires.setMonth(expires.getMonth() + 5);
+		expires.setDate(1);
+	}
+
+	document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute(
+		{
+			isCrossSubdomain,
+		},
+	)}`;
+};
+
+export const setSessionCookie = (name: string, value: string): void => {
+	if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
+		return;
+	}
+	document.cookie = `${name}=${value}; path=/;${getDomainAttribute()}`;
+};
+
+export const removeCookie = (name: string, currentDomainOnly = false): void => {
 	const expires = 'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
 	const path = 'path=/;';
 
@@ -50,13 +83,6 @@ const removeCookie = (name: string, currentDomainOnly = false): void => {
 	}
 };
 
-export const setSessionCookie = (name: string, value: string): void => {
-	if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
-		return;
-	}
-	document.cookie = `${name}=${value}; path=/;${getDomainAttribute()}`;
-};
-
 export const getCookie = (name: string): string | null => {
 	const cookieVal = getCookieValues(name);
 
@@ -64,10 +90,4 @@ export const getCookie = (name: string): string | null => {
 		return cookieVal[0];
 	}
 	return null;
-};
-
-export const cleanUp = (names: string[]): void => {
-	names.forEach((name) => {
-		removeCookie(name);
-	});
 };

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,0 +1,24 @@
+const getCookieValues = (name: string) => {
+	const nameEq = `${name}=`;
+	const cookies = document.cookie.split(';');
+
+	return cookies.reduce((acc: string[], cookie: string) => {
+		const cookieTrimmed: string = cookie.trim();
+		if (cookieTrimmed.startsWith(nameEq)) {
+			acc.push(
+				cookieTrimmed.substring(nameEq.length, cookieTrimmed.length),
+			);
+		}
+
+		return acc;
+	}, []);
+};
+
+export const getCookie = (name: string): string | null => {
+	const cookieVal = getCookieValues(name);
+
+	if (cookieVal.length > 0) {
+		return cookieVal[0];
+	}
+	return null;
+};

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,4 +1,5 @@
 const memoizedCookies: Map<string, string> = new Map<string, string>();
+const VALID_COOKIE_REGEX = /[()<>@,;"\\/[\]?={} \t]/g;
 
 export const getCookieValues = (name: string): string[] => {
 	const nameEq = `${name}=`;
@@ -17,8 +18,7 @@ export const getCookieValues = (name: string): string[] => {
 };
 
 // subset of https://github.com/guzzle/guzzle/pull/1131
-const isValidCookieValue = (name: string) =>
-	!/[()<>@,;"\\/[\]?={} \t]/g.test(name);
+const isValidCookieValue = (name: string) => !VALID_COOKIE_REGEX.test(name);
 
 const getShortDomain = ({ isCrossSubdomain = false } = {}) => {
 	const domain = document.domain || '';

--- a/src/getLocale.test.ts
+++ b/src/getLocale.test.ts
@@ -11,11 +11,11 @@ fetchMock.enableMocks();
 describe('getLocale', () => {
 	beforeEach(() => {
 		storage.local.clear();
-		cookies.cleanUp([KEY]);
+		cookies.removeCookie(KEY);
 		__resetCachedValue();
 	});
 
-	it('returns overrode locale if it exists', async () => {
+	it('returns overridden locale if it exists', async () => {
 		storage.local.set(KEY_OVERRIDE, 'CY');
 		cookies.setSessionCookie(KEY, 'GB');
 		const locale = await getLocale();

--- a/src/getLocale.test.ts
+++ b/src/getLocale.test.ts
@@ -1,56 +1,56 @@
 import fetchMock from 'jest-fetch-mock';
+import * as cookies from './cookies';
 import { __resetCachedValue, getLocale } from './getLocale';
-import { storage } from './storage';
 
-const KEY = 'gu.geolocation';
+const KEY = 'GU_geo_country';
 
 fetchMock.enableMocks();
 
 describe('getLocale', () => {
 	beforeEach(() => {
-		storage.local.clear();
+		cookies.cleanUp([KEY]);
 		__resetCachedValue();
 	});
 
 	it('gets a stored valid locale', async () => {
-		storage.local.set(KEY, 'CY');
+		cookies.setSessionCookie(KEY, 'CY');
 		const locale = await getLocale();
 		expect(locale).toBe('CY');
 	});
 
-	it('fetches the remote value is local is missing', async () => {
+	it('fetches the remote value if cookie is missing', async () => {
 		fetchMock.mockResponseOnce(JSON.stringify({ country: 'CZ' }));
 		const locale = await getLocale();
 		expect(locale).toBe('CZ');
-		expect(storage.local.get(KEY)).toBe('CZ');
+		expect(cookies.getCookie(KEY)).toBe('CZ');
 	});
 
 	it('ignores a stored invalid locale', async () => {
 		fetchMock.mockResponseOnce(JSON.stringify({ country: 'CZ' }));
-		storage.local.set(KEY, 'outerspace');
+		cookies.setSessionCookie(KEY, 'outerspace');
 		const locale = await getLocale();
 		expect(locale).toBe('CZ');
-		expect(storage.local.get(KEY)).toBe('CZ');
+		expect(cookies.getCookie(KEY)).toBe('CZ');
 	});
 
 	it('ignores an invalid remote response', async () => {
 		fetchMock.mockResponseOnce(JSON.stringify({ country: 'outerspace' }));
 		const locale = await getLocale();
 		expect(locale).toBeNull();
-		expect(storage.local.get(KEY)).toBeNull();
+		expect(cookies.getCookie(KEY)).toBeNull();
 	});
 
 	it('ignores an error in the remote response', async () => {
 		fetchMock.mockResponseOnce('regregergreg');
 		const locale = await getLocale();
 		expect(locale).toBeNull();
-		expect(storage.local.get(KEY)).toBeNull();
+		expect(cookies.getCookie(KEY)).toBeNull();
 	});
 
 	it('uses the cached value if available', async () => {
-		const spy = jest.spyOn(storage.local, 'get');
+		const spy = jest.spyOn(cookies, 'getCookie');
 
-		storage.local.set(KEY, 'CY');
+		cookies.setSessionCookie(KEY, 'CY');
 		const locale = await getLocale();
 		const locale2 = await getLocale();
 

--- a/src/getLocale.test.ts
+++ b/src/getLocale.test.ts
@@ -17,13 +17,13 @@ describe('getLocale', () => {
 
 	it('returns overridden locale if it exists', async () => {
 		storage.local.set(KEY_OVERRIDE, 'CY');
-		cookies.setSessionCookie(KEY, 'GB');
+		cookies.setSessionCookie({ name: KEY, value: 'GB' });
 		const locale = await getLocale();
 		expect(locale).toBe('CY');
 	});
 
 	it('gets a stored valid locale', async () => {
-		cookies.setSessionCookie(KEY, 'CY');
+		cookies.setSessionCookie({ name: KEY, value: 'CY' });
 		const locale = await getLocale();
 		expect(locale).toBe('CY');
 	});
@@ -32,35 +32,35 @@ describe('getLocale', () => {
 		fetchMock.mockResponseOnce(JSON.stringify({ country: 'CZ' }));
 		const locale = await getLocale();
 		expect(locale).toBe('CZ');
-		expect(cookies.getCookie(KEY)).toBe('CZ');
+		expect(cookies.getCookie({ name: KEY })).toBe('CZ');
 	});
 
 	it('ignores a stored invalid locale', async () => {
 		fetchMock.mockResponseOnce(JSON.stringify({ country: 'CZ' }));
-		cookies.setSessionCookie(KEY, 'outerspace');
+		cookies.setSessionCookie({ name: KEY, value: 'outerspace' });
 		const locale = await getLocale();
 		expect(locale).toBe('CZ');
-		expect(cookies.getCookie(KEY)).toBe('CZ');
+		expect(cookies.getCookie({ name: KEY })).toBe('CZ');
 	});
 
 	it('ignores an invalid remote response', async () => {
 		fetchMock.mockResponseOnce(JSON.stringify({ country: 'outerspace' }));
 		const locale = await getLocale();
 		expect(locale).toBeNull();
-		expect(cookies.getCookie(KEY)).toBeNull();
+		expect(cookies.getCookie({ name: KEY })).toBeNull();
 	});
 
 	it('ignores an error in the remote response', async () => {
 		fetchMock.mockResponseOnce('regregergreg');
 		const locale = await getLocale();
 		expect(locale).toBeNull();
-		expect(cookies.getCookie(KEY)).toBeNull();
+		expect(cookies.getCookie({ name: KEY })).toBeNull();
 	});
 
 	it('uses the cached value if available', async () => {
 		const spy = jest.spyOn(cookies, 'getCookie');
 
-		cookies.setSessionCookie(KEY, 'CY');
+		cookies.setSessionCookie({ name: KEY, value: 'CY' });
 		const locale = await getLocale();
 		const locale2 = await getLocale();
 

--- a/src/getLocale.test.ts
+++ b/src/getLocale.test.ts
@@ -1,15 +1,25 @@
 import fetchMock from 'jest-fetch-mock';
 import * as cookies from './cookies';
 import { __resetCachedValue, getLocale } from './getLocale';
+import { storage } from './storage';
 
 const KEY = 'GU_geo_country';
+const KEY_OVERRIDE = 'gu.geo.override';
 
 fetchMock.enableMocks();
 
 describe('getLocale', () => {
 	beforeEach(() => {
+		storage.local.clear();
 		cookies.cleanUp([KEY]);
 		__resetCachedValue();
+	});
+
+	it('returns overrode locale if it exists', async () => {
+		storage.local.set(KEY_OVERRIDE, 'CY');
+		cookies.setSessionCookie(KEY, 'GB');
+		const locale = await getLocale();
+		expect(locale).toBe('CY');
 	});
 
 	it('gets a stored valid locale', async () => {

--- a/src/getLocale.test.ts
+++ b/src/getLocale.test.ts
@@ -11,7 +11,7 @@ fetchMock.enableMocks();
 describe('getLocale', () => {
 	beforeEach(() => {
 		storage.local.clear();
-		cookies.removeCookie(KEY);
+		cookies.removeCookie({ name: KEY });
 		__resetCachedValue();
 	});
 

--- a/src/getLocale.ts
+++ b/src/getLocale.ts
@@ -33,7 +33,7 @@ export const getLocale = async (): Promise<CountryCode | null> => {
 	}
 
 	// return locale from cookie if it exists
-	const stored = getCookie('GU_geo_country');
+	const stored = getCookie({ name: 'GU_geo_country' });
 
 	if (stored && isValidCountryCode(stored)) {
 		return (locale = stored as CountryCode);
@@ -46,7 +46,7 @@ export const getLocale = async (): Promise<CountryCode | null> => {
 		)) as { country: CountryCode };
 
 		if (isValidCountryCode(country)) {
-			setSessionCookie(KEY, country);
+			setSessionCookie({ name: KEY, value: country });
 
 			// return it
 			return (locale = country);

--- a/src/getLocale.ts
+++ b/src/getLocale.ts
@@ -24,7 +24,7 @@ export const __resetCachedValue = (): void => (locale = void 0);
 export const getLocale = async (): Promise<CountryCode | null> => {
 	if (locale) return locale;
 
-	// return overrode geo from localStorage, used for changing geo only for development purposes
+	// return overridden geo from localStorage, used for changing geo only for development purposes
 	const geoOverride = storage.local.get(KEY_OVERRIDE) as CountryCode;
 
 	if (isValidCountryCode(geoOverride)) {

--- a/src/getLocale.ts
+++ b/src/getLocale.ts
@@ -6,10 +6,11 @@ import type { CountryCode } from './types/countries';
 const KEY = 'GU_geo_country';
 const KEY_OVERRIDE = 'gu.geo.override';
 const URL = 'https://api.nextgen.guardianapps.co.uk/geolocation';
+const COUNTRY_REGEX = /^[A-Z]{2}$/;
 
 // best guess that we have a valid code, without actually shipping the entire list
 const isValidCountryCode = (country: unknown) =>
-	isString(country) && /^[A-Z]{2}$/.test(country as string);
+	isString(country) && COUNTRY_REGEX.test(country as string);
 
 // we'll cache any successful lookups so we only have to do this once
 let locale: CountryCode | undefined;

--- a/src/getLocale.ts
+++ b/src/getLocale.ts
@@ -1,8 +1,10 @@
 import { getCookie, setSessionCookie } from './cookies';
 import { isString } from './isString';
+import { storage } from './storage';
 import type { CountryCode } from './types/countries';
 
 const KEY = 'GU_geo_country';
+const KEY_OVERRIDE = 'gu.geo.override';
 const URL = 'https://api.nextgen.guardianapps.co.uk/geolocation';
 
 // best guess that we have a valid code, without actually shipping the entire list
@@ -22,11 +24,18 @@ export const __resetCachedValue = (): void => (locale = void 0);
 export const getLocale = async (): Promise<CountryCode | null> => {
 	if (locale) return locale;
 
-	// return locale from cookie if it exists
-	const fromCookie = getCookie('GU_geo_country');
+	// return overrode geo from localStorage, used for changing geo only for development purposes
+	const geoOverride = storage.local.get(KEY_OVERRIDE) as CountryCode;
 
-	if (fromCookie && isValidCountryCode(fromCookie)) {
-		return (locale = fromCookie as CountryCode);
+	if (isValidCountryCode(geoOverride)) {
+		return (locale = geoOverride);
+	}
+
+	// return locale from cookie if it exists
+	const stored = getCookie('GU_geo_country');
+
+	if (stored && isValidCountryCode(stored)) {
+		return (locale = stored as CountryCode);
 	}
 
 	// use our API to get one

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,5 @@ export { isUndefined } from './isUndefined';
 export { loadScript } from './loadScript';
 export { storage } from './storage';
 export { timeAgo } from './timeAgo';
+export { getCookie } from './cookies';
 export { log, debug } from './logger';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,10 @@ export { isUndefined } from './isUndefined';
 export { loadScript } from './loadScript';
 export { storage } from './storage';
 export { timeAgo } from './timeAgo';
-export { getCookie } from './cookies';
+export {
+	getCookie,
+	removeCookie,
+	setCookie,
+	setSessionCookie,
+} from './cookies';
 export { log, debug } from './logger';

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -8,6 +8,11 @@ declare global {
 				unsubscribeFrom: TeamSubscription;
 				teams: () => string[];
 			};
+			config?: {
+				page?: {
+					isPreview: boolean;
+				};
+			};
 		};
 	}
 }


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

- Adds cookie module 
- Change locale logic to get the country code from newly [GU_geo_country](https://github.com/guardian/fastly-edge-cache/pull/906) cookie
- Return overridden geolocation if it exist to allow RR team test their banners in different countries
- Call API as fallback when cookie is not present and set its value to cookie
- Frontend PR: https://github.com/guardian/frontend/pull/23739

## Why?
Faster & more accurate geolocation 
