### PR TITLE
feat: `isObject` Function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 /* istanbul ignore file */
 
 export { getLocale } from './getLocale';
+export { isObject } from './isObject';
 export { isString } from './isString';
 export { isUndefined } from './isUndefined';
 export { loadScript } from './loadScript';
 export { storage } from './storage';
 export { timeAgo } from './timeAgo';
 export { log, debug } from './logger';
-export { isObject } from './isObject';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export { loadScript } from './loadScript';
 export { storage } from './storage';
 export { timeAgo } from './timeAgo';
 export { log, debug } from './logger';
+export { isObject } from './isObject';

--- a/src/isObject.ts
+++ b/src/isObject.ts
@@ -1,0 +1,4 @@
+// Based on a suggestion from the typescript-eslint project
+// https://github.com/typescript-eslint/typescript-eslint/issues/2118#issuecomment-641464651
+export const isObject = (a: unknown): a is Record<string, unknown> =>
+	typeof a === 'object' && a !== null;


### PR DESCRIPTION
## What does this change?

- Adds an `isObject` function

## Why?

Checks whether an `unknown` value is an object. Particularly useful when dealing with `JSON.parse`, as seen [here](https://github.com/guardian/apps-rendering/blob/c3cb9c7a25c0124c342408d790ba0e74ba8abcdb/src/client/interactives.ts#L7). Migrating upstream to `libs` from the implementation [in apps-rendering](https://github.com/guardian/apps-rendering/blob/1ed8a5d6208cc3972db05bbb474cd19b77e5ea18/src/lib.ts#L58).
