### PR TITLE
test: Allow Jest To Understand Guardian Packages

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,11 +2,12 @@
 // https://jestjs.io/docs/en/configuration.html
 
 module.exports = {
-	preset: 'ts-jest',
+	preset: 'ts-jest/presets/js-with-ts',
 	testEnvironment: 'jest-environment-jsdom-sixteen',
 	clearMocks: true,
 	collectCoverage: true,
 	collectCoverageFrom: ['src/**/*'],
 	coveragePathIgnorePatterns: ['types'],
+	transformIgnorePatterns: ['node_modules/(?!@guardian)'],
 	testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
 };


### PR DESCRIPTION
## What does this change?

- Allowed `ts-jest` to transform Guardian packages
- Used the `js-with-ts` preset to handle Guardian packages JS files

@sndrs I'm not quite sure what the correct prefix is for this PR. I've used `test:` because it touches the tests, but happy to change if that's not right.

## Why?

According to [our recommendations](https://github.com/guardian/recommendations/blob/master/npm-packages.md#using-guardian-npm-packages), Guardian packages aren't built to meet the requirements of any environment, and need to be transpiled wherever they are used. Accordingly, `@guardian/types`, added in #181, makes use of ESModules (`import` and `export` statements). These are not supported by default in Node 14, and therefore `@guardian/types` (and any other Guardian packages) needs to be included in our transpilation steps. This includes any transpilation done for our tests.

This PR tweaks our Jest config to allow `ts-jest` to transpile Guardian packages.
