### PR TITLE
refactor: `@guardian` deps should be peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@guardian/eslint-config-typescript": "0.5.0",
     "@guardian/pkgu": "0.6.0",
     "@guardian/prettier": "0.5.0",
+    "@guardian/types": "^6.1.0",
     "@rollup/plugin-typescript": "8.2.1",
     "@semantic-release/github": "7.2.3",
     "@types/jest": "26.0.23",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,10 @@
     "tsc": "tsc --noEmit",
     "validate": "npm-run-all tsc lint test build"
   },
-  "dependencies": {
-    "@guardian/types": "^6.1.0"
-  },
   "devDependencies": {
     "@guardian/eslint-config": "0.5.0",
     "@guardian/eslint-config-typescript": "0.5.0",
-    "@guardian/pkgu": "0.5.0",
+    "@guardian/pkgu": "0.6.0",
     "@guardian/prettier": "0.5.0",
     "@rollup/plugin-typescript": "8.2.1",
     "@semantic-release/github": "7.2.3",
@@ -64,6 +61,9 @@
     "tslib": "2.2.0",
     "typescript": "4.2.4",
     "wcag-contrast": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@guardian/types": "^6.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,10 +313,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config/-/eslint-config-0.5.0.tgz#ece14ec90b372932c7bf01992fc6d8ce58f7f26e"
   integrity sha512-THJn0wg7i9YjSVM9ofobsJgS+WH9ybrZH1+0CXLAebp0T53RGtgZUkek82mDg1h3DidsM+f7HSZqoQyrCbPzPw==
 
-"@guardian/pkgu@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/pkgu/-/pkgu-0.5.0.tgz#3f6f84706c34959b70902063ffce0ff2ed5c93ab"
-  integrity sha512-zV0DSErSDZZ7GT7AzmUY2wq+bvbCWVBXACqxYfa4KVezlMjM6qwD6soTVDW0wW4UZwynEGQSRBXnAFATrjuhiw==
+"@guardian/pkgu@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/pkgu/-/pkgu-0.6.0.tgz#abb5b136df6b1d72f9b653d87342ac4e16d90a6b"
+  integrity sha512-ZQAOr9AT5h13QB7vjjAKiuLqzFCwuEg6/LZBsKr+O05rITzTrsQhguY3IwV8jMCf76Y6Rzq8A39zE3C8eFBioA==
   dependencies:
     chalk "^4.1.0"
     execa "^5.0.0"


### PR DESCRIPTION
## What does this change?

#181 failed to build because we weren't using `peerDependencies` but a bug in pkgu (https://github.com/guardian/pkgu/commit/62ead251334623e9a7620a28f7e2dceba2b2158e) meant the build didn't break. this should fix both

## Why?

progress and stability