### PR TITLE
fix: use setUTC and getUTC methods for setting cookie expiry dates

### DIFF
--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -37,7 +37,7 @@ describe('cookies', () => {
 		MockDate.reset();
 	});
 
-	it('should be able to get a cookie', () => {
+	it('get a cookie', () => {
 		document.cookie =
 			'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649;';
 		expect(cookies.getCookie({ name: '__qca' })).toEqual(
@@ -45,7 +45,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('should be able to set a cookie with an expiry date in six months that preserves UTC time', () => {
+	it('set a cookie with an expiry date in six months that preserves UTC time', () => {
 		expect(document.cookie).toEqual('');
 		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
 		cookies.setCookie({
@@ -59,7 +59,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('should be able to set a cookie to expire in a specific number of days', () => {
+	it('set a cookie to expire in a specific number of days', () => {
 		expect(document.cookie).toEqual('');
 		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
 		cookies.setCookie({
@@ -72,7 +72,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('should be able to set a cookie for a specific number of days with an expiry that preserves UTC time', () => {
+	it('set a cookie for a specific number of days with an expiry that preserves UTC time', () => {
 		expect(document.cookie).toEqual('');
 		// BST started Sun 28th Mar 2021
 		MockDate.set('Sat Mar 27 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
@@ -86,7 +86,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('should not set a cookie when the cookie name is invalid', () => {
+	it('does not set a cookie when the cookie name is invalid', () => {
 		expect(document.cookie).toEqual('');
 		cookies.setCookie({
 			name: 'cookie-1-name-@',
@@ -95,7 +95,7 @@ describe('cookies', () => {
 		expect(document.cookie).toEqual('');
 	});
 
-	it('should not set a cookie when the cookie value is invalid', () => {
+	it('does not set a cookie when the cookie value is invalid', () => {
 		expect(document.cookie).toEqual('');
 		cookies.setCookie({
 			name: 'cookie-1-name',
@@ -104,7 +104,7 @@ describe('cookies', () => {
 		expect(document.cookie).toEqual('');
 	});
 
-	it('should be able to set a session cookie', () => {
+	it('set a session cookie', () => {
 		expect(document.cookie).toEqual('');
 		cookies.setSessionCookie({
 			name: 'cookie-1-name',
@@ -115,7 +115,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('should be able to set a session cookie for localhost', () => {
+	it('set a session cookie for localhost', () => {
 		Object.defineProperty(document, 'domain', {
 			value: 'localhost',
 		});
@@ -127,7 +127,7 @@ describe('cookies', () => {
 		expect(document.cookie).toEqual('cookie-1-name=cookie-1-value; path=/');
 	});
 
-	it('should not set a session cookie when the cookie name is invalid', () => {
+	it('does not set a session cookie when the cookie name is invalid', () => {
 		expect(document.cookie).toEqual('');
 		cookies.setSessionCookie({
 			name: 'cookie-1-name-@',
@@ -136,7 +136,7 @@ describe('cookies', () => {
 		expect(document.cookie).toEqual('');
 	});
 
-	it('should not set a session cookie when the cookie value is invalid', () => {
+	it('does not set a session cookie when the cookie value is invalid', () => {
 		expect(document.cookie).toEqual('');
 		cookies.setSessionCookie({
 			name: 'cookie-1-name',
@@ -145,7 +145,7 @@ describe('cookies', () => {
 		expect(document.cookie).toEqual('');
 	});
 
-	it('should be able to get a memoized cookie with days to live and cross subdomain', () => {
+	it('get a memoized cookie with days to live and cross subdomain', () => {
 		cookies.setCookie({
 			name: 'GU_geo_country',
 			value: 'GB',
@@ -162,7 +162,7 @@ describe('cookies', () => {
 		expect(spy).toHaveBeenCalledTimes(1);
 	});
 
-	it('should be able to get a memoized cookie with days to live', () => {
+	it('get a memoized cookie with days to live', () => {
 		cookies.setCookie({
 			name: 'GU_geo_country',
 			value: 'IT',
@@ -182,7 +182,7 @@ describe('cookies', () => {
 		expect(spy).not.toHaveBeenCalledTimes(2);
 	});
 
-	it('should be able to re-set a memoized cookie', () => {
+	it('re-set a memoized cookie', () => {
 		cookies.setCookie({
 			name: 'GU_geo_country',
 			value: 'GB',
@@ -203,7 +203,7 @@ describe('cookies', () => {
 		).toEqual('IT');
 	});
 
-	it('should be able to re-set a memoized session cookie', () => {
+	it('re-set a memoized session cookie', () => {
 		cookies.setSessionCookie({ name: 'GU_geo_country', value: 'GB' });
 		expect(
 			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
@@ -214,7 +214,7 @@ describe('cookies', () => {
 		).toEqual('GR');
 	});
 
-	it('should be able the remove a cookie and shorten the domain', () => {
+	it('remove a cookie and shorten the domain', () => {
 		document.cookie = 'cookie-1-name=cookie-1-value';
 
 		cookies.removeCookie({ name: 'cookie-1-name' });
@@ -228,7 +228,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('should not set a short domain when removing a cookie from localhost', () => {
+	it('does not set a short domain when removing a cookie from localhost', () => {
 		Object.defineProperty(document, 'domain', {
 			value: 'localhost',
 		});
@@ -246,7 +246,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('should not set a short domain when removing a cookie from preview', () => {
+	it('does not set a short domain when removing a cookie from preview', () => {
 		window.guardian = {
 			config: { page: { isPreview: true } },
 		};

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -46,7 +46,6 @@ describe('cookies', () => {
 	});
 
 	it('set a cookie with an expiry date in six months that preserves UTC time', () => {
-		expect(document.cookie).toEqual('');
 		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
 		cookies.setCookie({
 			name: 'cookie-1-name',
@@ -60,7 +59,6 @@ describe('cookies', () => {
 	});
 
 	it('set a cookie to expire in a specific number of days', () => {
-		expect(document.cookie).toEqual('');
 		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
 		cookies.setCookie({
 			name: 'cookie-1-name',
@@ -73,7 +71,6 @@ describe('cookies', () => {
 	});
 
 	it('set a cookie for a specific number of days with an expiry that preserves UTC time', () => {
-		expect(document.cookie).toEqual('');
 		// BST started Sun 28th Mar 2021
 		MockDate.set('Sat Mar 27 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
 		cookies.setCookie({
@@ -87,7 +84,6 @@ describe('cookies', () => {
 	});
 
 	it('does not set a cookie when the cookie name is invalid', () => {
-		expect(document.cookie).toEqual('');
 		cookies.setCookie({
 			name: 'cookie-1-name-@',
 			value: 'cookie-1-value',
@@ -96,7 +92,6 @@ describe('cookies', () => {
 	});
 
 	it('does not set a cookie when the cookie value is invalid', () => {
-		expect(document.cookie).toEqual('');
 		cookies.setCookie({
 			name: 'cookie-1-name',
 			value: 'cookie-1-value-<',
@@ -105,7 +100,6 @@ describe('cookies', () => {
 	});
 
 	it('set a session cookie', () => {
-		expect(document.cookie).toEqual('');
 		cookies.setSessionCookie({
 			name: 'cookie-1-name',
 			value: 'cookie-1-value',
@@ -128,7 +122,6 @@ describe('cookies', () => {
 	});
 
 	it('does not set a session cookie when the cookie name is invalid', () => {
-		expect(document.cookie).toEqual('');
 		cookies.setSessionCookie({
 			name: 'cookie-1-name-@',
 			value: 'cookie-1-value',
@@ -137,7 +130,6 @@ describe('cookies', () => {
 	});
 
 	it('does not set a session cookie when the cookie value is invalid', () => {
-		expect(document.cookie).toEqual('');
 		cookies.setSessionCookie({
 			name: 'cookie-1-name',
 			value: 'cookie-1-value-<',

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -37,7 +37,7 @@ describe('cookies', () => {
 		MockDate.reset();
 	});
 
-	it('get a cookie', () => {
+	it('gets a cookie', () => {
 		document.cookie =
 			'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649;';
 		expect(cookies.getCookie({ name: '__qca' })).toEqual(
@@ -45,7 +45,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('set a cookie with an expiry date in six months that preserves UTC time', () => {
+	it('sets a cookie with an expiry date in six months that preserves UTC time', () => {
 		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
 		cookies.setCookie({
 			name: 'cookie-1-name',
@@ -58,7 +58,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('set a cookie to expire in a specific number of days', () => {
+	it('sets a cookie to expire in a specific number of days', () => {
 		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
 		cookies.setCookie({
 			name: 'cookie-1-name',
@@ -70,7 +70,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('set a cookie for a specific number of days with an expiry that preserves UTC time', () => {
+	it('sets a cookie to expire in a specific number of days that preserves UTC time', () => {
 		// BST started Sun 28th Mar 2021
 		MockDate.set('Sat Mar 27 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
 		cookies.setCookie({
@@ -99,7 +99,7 @@ describe('cookies', () => {
 		expect(document.cookie).toEqual('');
 	});
 
-	it('set a session cookie', () => {
+	it('sets a session cookie', () => {
 		cookies.setSessionCookie({
 			name: 'cookie-1-name',
 			value: 'cookie-1-value',
@@ -109,7 +109,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('set a session cookie for localhost', () => {
+	it('sets a session cookie for localhost', () => {
 		Object.defineProperty(document, 'domain', {
 			value: 'localhost',
 		});
@@ -137,7 +137,7 @@ describe('cookies', () => {
 		expect(document.cookie).toEqual('');
 	});
 
-	it('get a memoized cookie with days to live and cross subdomain', () => {
+	it('gets a memoized cookie with days to live and cross subdomain', () => {
 		cookies.setCookie({
 			name: 'GU_geo_country',
 			value: 'GB',
@@ -154,7 +154,7 @@ describe('cookies', () => {
 		expect(spy).toHaveBeenCalledTimes(1);
 	});
 
-	it('get a memoized cookie with days to live', () => {
+	it('gets a memoized cookie with days to live', () => {
 		cookies.setCookie({
 			name: 'GU_geo_country',
 			value: 'IT',
@@ -174,7 +174,7 @@ describe('cookies', () => {
 		expect(spy).not.toHaveBeenCalledTimes(2);
 	});
 
-	it('re-set a memoized cookie', () => {
+	it('re-sets a memoized cookie', () => {
 		cookies.setCookie({
 			name: 'GU_geo_country',
 			value: 'GB',
@@ -195,7 +195,7 @@ describe('cookies', () => {
 		).toEqual('IT');
 	});
 
-	it('re-set a memoized session cookie', () => {
+	it('re-sets a memoized session cookie', () => {
 		cookies.setSessionCookie({ name: 'GU_geo_country', value: 'GB' });
 		expect(
 			cookies.getCookie({ name: 'GU_geo_country', shouldMemoize: true }),
@@ -206,7 +206,7 @@ describe('cookies', () => {
 		).toEqual('GR');
 	});
 
-	it('remove a cookie and shorten the domain', () => {
+	it('removes a cookie and sets a short domain', () => {
 		document.cookie = 'cookie-1-name=cookie-1-value';
 
 		cookies.removeCookie({ name: 'cookie-1-name' });
@@ -220,7 +220,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('does not set a short domain when removing a cookie from localhost', () => {
+	it('removes a cookie and does not set a short domain for localhost', () => {
 		Object.defineProperty(document, 'domain', {
 			value: 'localhost',
 		});
@@ -238,7 +238,7 @@ describe('cookies', () => {
 		);
 	});
 
-	it('does not set a short domain when removing a cookie from preview', () => {
+	it('removes a cookie and does not set a short domain for preview', () => {
 		window.guardian = {
 			config: { page: { isPreview: true } },
 		};

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -5,7 +5,6 @@ describe('cookies', () => {
 	let cookieValue = '';
 
 	beforeAll(() => {
-		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
 		Object.defineProperty(document, 'cookie', {
 			get() {
 				return cookieValue
@@ -25,10 +24,6 @@ describe('cookies', () => {
 		});
 	});
 
-	afterAll(() => {
-		MockDate.reset();
-	});
-
 	beforeEach(() => {
 		cookieValue = '';
 		Object.defineProperty(document, 'domain', {
@@ -36,6 +31,10 @@ describe('cookies', () => {
 			writable: true,
 			configurable: true,
 		});
+	});
+
+	afterEach(() => {
+		MockDate.reset();
 	});
 
 	it('should be able to get a cookie', () => {
@@ -46,8 +45,9 @@ describe('cookies', () => {
 		);
 	});
 
-	it('should be able to set a cookie', () => {
+	it('should be able to set a cookie with an expiry date in six months that preserves UTC time', () => {
 		expect(document.cookie).toEqual('');
+		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
 		cookies.setCookie({
 			name: 'cookie-1-name',
 			value: 'cookie-1-value',
@@ -59,8 +59,9 @@ describe('cookies', () => {
 		);
 	});
 
-	it('should be able to set a cookie for a specific number of days', () => {
+	it('should be able to set a cookie to expire in a specific number of days', () => {
 		expect(document.cookie).toEqual('');
+		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
 		cookies.setCookie({
 			name: 'cookie-1-name',
 			value: 'cookie-1-value',
@@ -68,6 +69,20 @@ describe('cookies', () => {
 		});
 		expect(document.cookie).toEqual(
 			'cookie-1-name=cookie-1-value; path=/; expires=Sun, 24 Nov 2019 12:00:00 GMT; domain=.theguardian.com',
+		);
+	});
+
+	it('should be able to set a cookie for a specific number of days with an expiry that preserves UTC time', () => {
+		expect(document.cookie).toEqual('');
+		// BST started Sun 28th Mar 2021
+		MockDate.set('Sat Mar 27 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
+		cookies.setCookie({
+			name: 'cookie-1-name',
+			value: 'cookie-1-value',
+			daysToLive: 7,
+		});
+		expect(document.cookie).toEqual(
+			'cookie-1-name=cookie-1-value; path=/; expires=Sat, 03 Apr 2021 12:00:00 GMT; domain=.theguardian.com',
 		);
 	});
 

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -66,10 +66,10 @@ export const setCookie = ({
 	}
 
 	if (daysToLive) {
-		expires.setDate(expires.getDate() + daysToLive);
+		expires.setUTCDate(expires.getDate() + daysToLive);
 	} else {
-		expires.setMonth(expires.getMonth() + 5);
-		expires.setDate(1);
+		expires.setUTCMonth(expires.getMonth() + 5);
+		expires.setUTCDate(1);
 	}
 
 	document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute(

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -66,9 +66,9 @@ export const setCookie = ({
 	}
 
 	if (daysToLive) {
-		expires.setUTCDate(expires.getDate() + daysToLive);
+		expires.setUTCDate(expires.getUTCDate() + daysToLive);
 	} else {
-		expires.setUTCMonth(expires.getMonth() + 5);
+		expires.setUTCMonth(expires.getUTCMonth() + 5);
 		expires.setUTCDate(1);
 	}
 


### PR DESCRIPTION
## What does this change?

Update `cookies.ts setCookie()` to set cookie expiry dates with [`setUTC`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCDate
) and [`getUTC`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDate) methods to maintain UTC time.

## Why?

The current logic for setting cookie expiry dates is setting local timezone time rather than maintaining UTC time.

The test for `setCookie` fails because it (correctly) expects the expiry time to be UTC.

Because non-UTC methods are used to set the expiry date, it incorrectly sets the time to local time.

Hence `expires.toUTCString()` outputs local time rather than the expected adjusted UTC time.

### Reproduction

```js
// Date with GMT timezone within BST period
var a = new Date('Mon Jun 14 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
var b = new Date('Mon Jun 14 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');

// Set date to move into GMT
a.setMonth(10);
b.setUTCMonth(10);

console.log(a.toUTCString()); // Sun, 14 Nov 2021 13:00:00 GMT - incorrect
console.log(b.toUTCString()); // Sun, 14 Nov 2021 12:00:00 GMT - correct
``` 
