### PR TITLE
feat: use type predicates

### DIFF
--- a/src/getLocale.ts
+++ b/src/getLocale.ts
@@ -10,7 +10,7 @@ const COUNTRY_REGEX = /^[A-Z]{2}$/;
 
 // best guess that we have a valid code, without actually shipping the entire list
 const isValidCountryCode = (country: unknown) =>
-	isString(country) && COUNTRY_REGEX.test(country as string);
+	isString(country) && COUNTRY_REGEX.test(country);
 
 // we'll cache any successful lookups so we only have to do this once
 let locale: CountryCode | undefined;

--- a/src/isBoolean.ts
+++ b/src/isBoolean.ts
@@ -1,3 +1,3 @@
-export const isBoolean = (_: unknown): boolean => {
+export const isBoolean = (_: unknown): _ is boolean => {
 	return typeof _ === 'boolean';
 };

--- a/src/isString.ts
+++ b/src/isString.ts
@@ -1,3 +1,3 @@
-export const isString = (_: unknown): boolean => {
+export const isString = (_: unknown): _ is string => {
 	return Object.prototype.toString.call(_) === '[object String]';
 };

--- a/src/isUndefined.ts
+++ b/src/isUndefined.ts
@@ -1,3 +1,3 @@
 // the lodash way https://github.com/lodash/lodash/blob/master/isUndefined.js
 
-export const isUndefined = (_: unknown): e is undefined => _ === undefined;
+export const isUndefined = (_: unknown): _ is undefined => _ === undefined;

--- a/src/isUndefined.ts
+++ b/src/isUndefined.ts
@@ -1,3 +1,3 @@
 // the lodash way https://github.com/lodash/lodash/blob/master/isUndefined.js
 
-export const isUndefined = (_: unknown): boolean => _ === undefined;
+export const isUndefined = (_: unknown): e is undefined => _ === undefined;


### PR DESCRIPTION
## What does this change?

Let the Typescript compiler know the type of functions using [type predicates]. Especially useful if you want to filter an array of varying types.

Applied to the following is* methods:
- `isUndefined`
- `isBoolean`
- `isString`

See example [on TS Playground](https://www.typescriptlang.org/play?jsx=0#code/MYewdgzgLgBAhgJwXAnjAvDA2gKBjAcjgIBo9CAjU8g4a-ARjPwCZmYBmdgVzABMApgDMAlmAF8e-YWInsw3ADaL2Ab3hgAXIRAUAVgOBQCMAL7soCbgPZC4iiDfJ2HTgLo4coSLBEQAqtKi4nwYMAAUAPravADWYCAA7mAAlNqRMH4wvILBEhgAfDAZ6KXZQbJ8ANxe4NDwSKgA8kKBuZVhiMgoAHSiilACCOF+bTIhKZ7e9X4AQiAgigJwYGFRMWDxSanpmRAwFAtLK4UwqjgAkAgCUNwIq1AoAA4CIELFGGUEh4vLYAQ1Uw1aawLrNITzX4rfaYMG9fqDYZzI5-Sa1Hx7ADKljEAHM1tFyltkmkPlloAg8adzlcbndVk19IYoD0nggQFAOc8BD1OdjKWBcT1gPZFFEUp9MAQsLoDEYYPy8W4ATggej6nCWorBTCGt0+iIBkMRhBtbjJkA)

[type predicates]: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates

## Why?

Allows to use the power of Typescript.

This is a conclusion from a reflection on `undefined` in JS: https://github.com/orgs/guardian/teams/client-side-infra/discussions/20
