### PR TITLE
test: 100% coverage for `timeAgo`

### DIFF
--- a/src/timeAgo.test.ts
+++ b/src/timeAgo.test.ts
@@ -220,4 +220,9 @@ describe('timeAgo', () => {
 		expect(timeAgo(eightDaysAgo)).toBe('9 Nov 2019');
 		expect(timeAgo(aWhileBack)).toBe('2 Apr 2017');
 	});
+
+	it('returns false on future dates', () => {
+		const tomorrow = new Date(Date.UTC(2019, 10, 18, 10, 0, 0)).getTime();
+		expect(timeAgo(tomorrow)).toBe(false);
+	});
 });

--- a/src/timeAgo.ts
+++ b/src/timeAgo.ts
@@ -50,8 +50,7 @@ const getSuffix = (type: Unit, value: number, verbose?: boolean): string => {
 	const shouldPluralise = value !== 1;
 	switch (type) {
 		case 's': {
-			if (verbose && shouldPluralise) return ' seconds ago';
-			if (verbose) return ' second ago';
+			if (verbose) return ' seconds ago';
 			return 's ago';
 		}
 		case 'm': {

--- a/src/timeAgo.ts
+++ b/src/timeAgo.ts
@@ -50,6 +50,7 @@ const getSuffix = (type: Unit, value: number, verbose?: boolean): string => {
 	const shouldPluralise = value !== 1;
 	switch (type) {
 		case 's': {
+			// Always pluralised, as less than 15 seconds returns “now”
 			if (verbose) return ' seconds ago';
 			return 's ago';
 		}
@@ -64,6 +65,7 @@ const getSuffix = (type: Unit, value: number, verbose?: boolean): string => {
 			return 'h ago';
 		}
 		case 'd': {
+			// Always pluralised, as less than 2 days returns “Yesterday HH:MM”
 			if (verbose) return ' days ago';
 			return 'd ago';
 		}

--- a/src/timeAgo.ts
+++ b/src/timeAgo.ts
@@ -64,8 +64,7 @@ const getSuffix = (type: Unit, value: number, verbose?: boolean): string => {
 			return 'h ago';
 		}
 		case 'd': {
-			if (verbose && shouldPluralise) return ' days ago';
-			if (verbose) return ' day ago';
+			if (verbose) return ' days ago';
 			return 'd ago';
 		}
 	}


### PR DESCRIPTION
## What does this change?

Achieve 100% coverage in `timeAgo`.

- remove singular verbose “second ago”
- remove singular “day ago”
- add test for future dates

## Why?

[Greener is better!](https://coveralls.io/builds/40626836/source?filename=src%2FtimeAgo.ts)
