### PR TITLE
feat: throw error if cookie name or value is invalid

### DIFF
--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -84,18 +84,26 @@ describe('cookies', () => {
 	});
 
 	it('does not set a cookie when the cookie name is invalid', () => {
-		cookies.setCookie({
-			name: 'cookie-1-name-@',
-			value: 'cookie-1-value',
-		});
+		expect(() =>
+			cookies.setCookie({
+				name: 'cookie-1-name-@',
+				value: 'cookie-1-value',
+			}),
+		).toThrowError(
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') .cookie-1-name-@=cookie-1-value`,
+		);
 		expect(document.cookie).toEqual('');
 	});
 
 	it('does not set a cookie when the cookie value is invalid', () => {
-		cookies.setCookie({
-			name: 'cookie-1-name',
-			value: 'cookie-1-value-<',
-		});
+		expect(() =>
+			cookies.setCookie({
+				name: 'cookie-1-name',
+				value: 'cookie-1-value-<',
+			}),
+		).toThrowError(
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') .cookie-1-name=cookie-1-value-<`,
+		);
 		expect(document.cookie).toEqual('');
 	});
 
@@ -122,18 +130,26 @@ describe('cookies', () => {
 	});
 
 	it('does not set a session cookie when the cookie name is invalid', () => {
-		cookies.setSessionCookie({
-			name: 'cookie-1-name-@',
-			value: 'cookie-1-value',
-		});
+		expect(() =>
+			cookies.setSessionCookie({
+				name: 'cookie-1-name-@',
+				value: 'cookie-1-value',
+			}),
+		).toThrowError(
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') .cookie-1-name-@=cookie-1-value`,
+		);
 		expect(document.cookie).toEqual('');
 	});
 
-	it('does not set a session cookie when the cookie value is invalid', () => {
-		cookies.setSessionCookie({
-			name: 'cookie-1-name',
-			value: 'cookie-1-value-<',
-		});
+	it('does not set a cookie when the cookie value is invalid', () => {
+		expect(() =>
+			cookies.setSessionCookie({
+				name: 'cookie-1-name',
+				value: 'cookie-1-value-<',
+			}),
+		).toThrowError(
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') .cookie-1-name=cookie-1-value-<`,
+		);
 		expect(document.cookie).toEqual('');
 	});
 

--- a/src/cookies.test.ts
+++ b/src/cookies.test.ts
@@ -90,7 +90,7 @@ describe('cookies', () => {
 				value: 'cookie-1-value',
 			}),
 		).toThrowError(
-			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') .cookie-1-name-@=cookie-1-value`,
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') cookie-1-name-@=cookie-1-value`,
 		);
 		expect(document.cookie).toEqual('');
 	});
@@ -102,7 +102,7 @@ describe('cookies', () => {
 				value: 'cookie-1-value-<',
 			}),
 		).toThrowError(
-			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') .cookie-1-name=cookie-1-value-<`,
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') cookie-1-name=cookie-1-value-<`,
 		);
 		expect(document.cookie).toEqual('');
 	});
@@ -136,7 +136,7 @@ describe('cookies', () => {
 				value: 'cookie-1-value',
 			}),
 		).toThrowError(
-			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') .cookie-1-name-@=cookie-1-value`,
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') cookie-1-name-@=cookie-1-value`,
 		);
 		expect(document.cookie).toEqual('');
 	});
@@ -148,7 +148,7 @@ describe('cookies', () => {
 				value: 'cookie-1-value-<',
 			}),
 		).toThrowError(
-			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') .cookie-1-name=cookie-1-value-<`,
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') cookie-1-name=cookie-1-value-<`,
 		);
 		expect(document.cookie).toEqual('');
 	});

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,5 +1,6 @@
 const memoizedCookies: Map<string, string> = new Map<string, string>();
 const COOKIE_REGEX = /[()<>@,;"\\/[\]?={} \t]/g;
+const ERR_INVALID_COOKIE = `Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}')`;
 
 export const getCookieValues = (name: string): string[] => {
 	const nameEq = `${name}=`;
@@ -19,6 +20,9 @@ export const getCookieValues = (name: string): string[] => {
 
 // subset of https://github.com/guzzle/guzzle/pull/1131
 const isValidCookieValue = (name: string) => !COOKIE_REGEX.test(name);
+
+const isValidCookie = (name: string, value: string): boolean =>
+	isValidCookieValue(name) && isValidCookieValue(value);
 
 const getShortDomain = ({ isCrossSubdomain = false } = {}) => {
 	const domain = document.domain || '';
@@ -61,8 +65,8 @@ export const setCookie = ({
 }): void => {
 	const expires = new Date();
 
-	if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
-		return;
+	if (!isValidCookie(name, value)) {
+		throw new Error(`${ERR_INVALID_COOKIE} .${name}=${value}`);
 	}
 
 	if (daysToLive) {
@@ -97,9 +101,10 @@ export const setSessionCookie = ({
 	name: string;
 	value: string;
 }): void => {
-	if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
-		return;
+	if (!isValidCookie(name, value)) {
+		throw new Error(`${ERR_INVALID_COOKIE} .${name}=${value}`);
 	}
+
 	document.cookie = `${name}=${value}; path=/;${getDomainAttribute()}`;
 
 	// If the cookie is already memoized we want to replace its value

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -66,7 +66,7 @@ export const setCookie = ({
 	const expires = new Date();
 
 	if (!isValidCookie(name, value)) {
-		throw new Error(`${ERR_INVALID_COOKIE} .${name}=${value}`);
+		throw new Error(`${ERR_INVALID_COOKIE} ${name}=${value}`);
 	}
 
 	if (daysToLive) {
@@ -102,7 +102,7 @@ export const setSessionCookie = ({
 	value: string;
 }): void => {
 	if (!isValidCookie(name, value)) {
-		throw new Error(`${ERR_INVALID_COOKIE} .${name}=${value}`);
+		throw new Error(`${ERR_INVALID_COOKIE} ${name}=${value}`);
 	}
 
 	document.cookie = `${name}=${value}; path=/;${getDomainAttribute()}`;


### PR DESCRIPTION
## What does this change?

Throw an error if the cookie name or value is invalid as suggested by @sndrs 

## Why?

Make errors explicit.
