### PR TITLE
feat: migrate ophan from types

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Inject an external JavaScript file.
 
 Selectively log team-specific messages to the console.
 
+### [`ophan`](./src/ophan.README.md)
+
+Types related to Ophan.
+
 ### [`storage`](./src/storage.README.md)
 
 Robust API over `localStorage` and `sessionStorage`.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [`isUndefined`](#isundefined)
   - [`loadScript`](#loadscript)
   - [`log`/`debug`](#logdebug)
+  - [`ophan`](#ophan)
   - [`storage`](#storage)
   - [`timeAgo`](#timeago)
 - [Installation](#installation)

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,16 @@ export { isString } from './isString';
 export { isUndefined } from './isUndefined';
 export { loadScript } from './loadScript';
 export { debug, log } from './logger';
+export type {
+	OphanABEvent,
+	OphanABPayload,
+	OphanAction,
+	OphanComponent,
+	OphanComponentEvent,
+	OphanComponentType,
+	OphanProduct,
+	TestMeta,
+} from './ophan';
 export { storage } from './storage';
 export { timeAgo } from './timeAgo';
 export type { Switches } from './types/switches';

--- a/src/ophan.README.md
+++ b/src/ophan.README.md
@@ -1,0 +1,18 @@
+# `ophan`
+
+Types related to Ophan.
+
+### Usage
+
+```js
+import type {
+    OphanABEvent,
+    OphanABPayload,
+    OphanAction,
+    OphanComponent,
+    OphanComponentEvent,
+    OphanComponentType,
+    OphanProduct,
+    TestMeta,
+} from '@guardian/libs';
+```

--- a/src/ophan.ts
+++ b/src/ophan.ts
@@ -1,0 +1,100 @@
+// ----- Types ----- //
+
+/**
+ * an individual A/B test, structured for Ophan
+ */
+type OphanABEvent = {
+	variantName: string;
+	complete: string | boolean;
+	campaignCodes?: string[];
+};
+
+/**
+ * the actual payload we send to Ophan: an object of OphanABEvents with test IDs as keys
+ */
+type OphanABPayload = {
+	abTestRegister: Record<string, OphanABEvent>;
+};
+
+type OphanProduct =
+	| 'CONTRIBUTION'
+	| 'RECURRING_CONTRIBUTION'
+	| 'MEMBERSHIP_SUPPORTER'
+	| 'MEMBERSHIP_PATRON'
+	| 'MEMBERSHIP_PARTNER'
+	| 'DIGITAL_SUBSCRIPTION'
+	| 'PRINT_SUBSCRIPTION';
+
+type OphanAction =
+	| 'INSERT'
+	| 'VIEW'
+	| 'EXPAND'
+	| 'LIKE'
+	| 'DISLIKE'
+	| 'SUBSCRIBE'
+	| 'ANSWER'
+	| 'VOTE'
+	| 'CLICK';
+
+type OphanComponentType =
+	| 'READERS_QUESTIONS_ATOM'
+	| 'QANDA_ATOM'
+	| 'PROFILE_ATOM'
+	| 'GUIDE_ATOM'
+	| 'TIMELINE_ATOM'
+	| 'NEWSLETTER_SUBSCRIPTION'
+	| 'SURVEYS_QUESTIONS'
+	| 'ACQUISITIONS_EPIC'
+	| 'ACQUISITIONS_ENGAGEMENT_BANNER'
+	| 'ACQUISITIONS_THANK_YOU_EPIC'
+	| 'ACQUISITIONS_HEADER'
+	| 'ACQUISITIONS_FOOTER'
+	| 'ACQUISITIONS_INTERACTIVE_SLICE'
+	| 'ACQUISITIONS_NUGGET'
+	| 'ACQUISITIONS_STANDFIRST'
+	| 'ACQUISITIONS_THRASHER'
+	| 'ACQUISITIONS_EDITORIAL_LINK'
+	| 'ACQUISITIONS_SUBSCRIPTIONS_BANNER'
+	| 'ACQUISITIONS_OTHER'
+	| 'SIGN_IN_GATE'
+	| 'RETENTION_ENGAGEMENT_BANNER'
+	| 'RETENTION_EPIC';
+
+type OphanComponent = {
+	componentType: OphanComponentType;
+	id?: string;
+	products?: OphanProduct[];
+	campaignCode?: string;
+	labels?: string[];
+};
+
+type OphanComponentEvent = {
+	component: OphanComponent;
+	action: OphanAction;
+	value?: string;
+	id?: string;
+	abTest?: {
+		name: string;
+		variant: string;
+	};
+};
+
+type TestMeta = {
+	abTestName: string;
+	abTestVariant: string;
+	campaignCode: string;
+	campaignId?: string;
+	componentType: OphanComponentType;
+	products?: OphanProduct[];
+};
+
+export type {
+	OphanABEvent,
+	OphanABPayload,
+	OphanAction,
+	OphanComponent,
+	OphanComponentEvent,
+	OphanComponentType,
+	OphanProduct,
+	TestMeta,
+};


### PR DESCRIPTION
## What does this change?

* Migrates ophan from `@guardian/types` to `@guardian/libs`

## Why?

See https://github.com/guardian/types/issues/136