### PR TITLE
build(deps-dev): Bump dependencies (12/07)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@guardian/prettier": "0.6.0",
     "@rollup/plugin-typescript": "8.2.1",
     "@semantic-release/github": "7.2.3",
-    "@types/jest": "26.0.23",
+    "@types/jest": "26.0.24",
     "@types/wcag-contrast": "3.0.0",
     "conventional-changelog-conventionalcommits": "4.6.0",
     "eslint": "7.30.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rollup-plugin-terser": "7.0.2",
     "semantic-release": "17.4.4",
     "ts-jest": "27.0.3",
-    "ts-node": "10.0.0",
+    "ts-node": "10.1.0",
     "tslib": "2.3.0",
     "typescript": "4.3.5",
     "wcag-contrast": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mockdate": "3.0.5",
     "npm-run-all": "4.1.5",
     "prettier": "2.3.2",
-    "rollup": "2.52.7",
+    "rollup": "2.53.1",
     "rollup-plugin-size": "0.2.2",
     "rollup-plugin-terser": "7.0.2",
     "semantic-release": "17.4.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/wcag-contrast": "3.0.0",
     "conventional-changelog-conventionalcommits": "4.6.0",
     "eslint": "7.30.0",
-    "husky": "7.0.0",
+    "husky": "7.0.1",
     "jest": "27.0.6",
     "jest-fetch-mock": "3.0.3",
     "mockdate": "3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,10 +1064,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.0.23":
-  version "26.0.23"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
-  integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
+"@types/jest@26.0.24":
+  version "26.0.24"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
+  integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6772,10 +6772,10 @@ ts-jest@27.0.3:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-node@10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.0.0.tgz#05f10b9a716b0b624129ad44f0ea05dac84ba3be"
-  integrity sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==
+ts-node@10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.1.0.tgz#e656d8ad3b61106938a867f69c39a8ba6efc966e"
+  integrity sha512-6szn3+J9WyG2hE+5W8e0ruZrzyk1uFLYye6IGMBadnOzDh8aP7t8CbFpsfCiEx2+wMixAhjFt7lOZC4+l+WbEA==
   dependencies:
     "@tsconfig/node10" "^1.0.7"
     "@tsconfig/node12" "^1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3293,10 +3293,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.0.tgz#3dbd5d28e76234689ee29bb41e048f28e3e46616"
-  integrity sha512-xK7lO0EtSzfFPiw+oQncQVy/XqV7UVVjxBByc+Iv5iK3yhW9boDoWgvZy3OGo48QKg/hUtZkzz0hi2HXa0kn7w==
+husky@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.1.tgz#579f4180b5da4520263e8713cc832942b48e1f1c"
+  integrity sha512-gceRaITVZ+cJH9sNHqx5tFwbzlLCVxtVZcusME8JYQ8Edy5mpGDOqD8QBCdMhpyo9a+JXddnujQ4rpY2Ff9SJA==
 
 iconv-lite@0.4.24:
   version "0.4.24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6031,10 +6031,10 @@ rollup-plugin-terser@7.0.2:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup@2.52.7:
-  version "2.52.7"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.52.7.tgz#e15a8bf734f6e4c204b7cdf33521151310250cb2"
-  integrity sha512-55cSH4CCU6MaPr9TAOyrIC+7qFCHscL7tkNsm1MBfIJRRqRbCEY0mmeFn4Wg8FKsHtEH8r389Fz38r/o+kgXLg==
+rollup@2.53.1:
+  version "2.53.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.53.1.tgz#b60439efd1eb41bdb56630509bd99aae78b575d3"
+  integrity sha512-yiTCvcYXZEulNWNlEONOQVlhXA/hgxjelFSjNcrwAAIfYx/xqjSHwqg/cCaWOyFRKr+IQBaXwt723m8tCaIUiw==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
* bump rollup from 2.52.7 to 2.53.1
* bump husky from 7.0.0 to 7.0.1
* bump @types/jest from 26.0.23 to 26.0.24
* bump ts-node from 10.0.0 to 10.1.0