### PR TITLE
feat: Add ArticleDesign.Correction

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -34,6 +34,7 @@ enum ArticleDesign {
 	PhotoEssay,
 	PrintShop,
 	Obituary,
+	Correction,
 }
 
 enum ArticleDisplay {


### PR DESCRIPTION
## What does this change?

This change adds the `Correction` option to the `ArticleDesign` enum from `format`.

## Why?

The change corrects some drift between here and `@guardian/types` following https://github.com/guardian/types/pull/164.
