### PR TITLE
feat: Add Consent related Ophan component types

### DIFF
--- a/src/@types/ophan.README.md
+++ b/src/@types/ophan.README.md
@@ -2,6 +2,8 @@
 
 Types related to Ophan.
 
+Ophan has an official type system described in [thrift](https://github.com/guardian/ophan/tree/abb022b43a1fa3922a6cf24478c4a8982cd13b79/event-model/src/main/thrift). In particular, updates in [componentevent.thrift](https://github.com/guardian/ophan/blob/abb022b43a1fa3922a6cf24478c4a8982cd13b79/event-model/src/main/thrift/componentevent.thrift) should be mirrored in this repository.
+
 ## Example
 
 ```js

--- a/src/@types/ophan.ts
+++ b/src/@types/ophan.ts
@@ -34,7 +34,11 @@ type OphanAction =
 	| 'SUBSCRIBE'
 	| 'ANSWER'
 	| 'VOTE'
-	| 'CLICK';
+	| 'CLICK'
+	| 'ACCEPT_DEFAULT_CONSENT'
+	| 'MANAGE_CONSENT'
+	| 'CONSENT_ACCEPT_ALL'
+	| 'CONSENT_REJECT_ALL';
 
 type OphanComponentType =
 	| 'READERS_QUESTIONS_ATOM'
@@ -58,7 +62,8 @@ type OphanComponentType =
 	| 'ACQUISITIONS_OTHER'
 	| 'SIGN_IN_GATE'
 	| 'RETENTION_ENGAGEMENT_BANNER'
-	| 'RETENTION_EPIC';
+	| 'RETENTION_EPIC'
+	| 'CONSENT';
 
 type OphanComponent = {
 	componentType: OphanComponentType;


### PR DESCRIPTION

## What does this change?

The Ophan thrift model was recently updated ( https://github.com/guardian/ophan/pull/4258 ) to allow for consent related component events. This brings the same change to this repository so that we can correctly send those events from DCR client side.
