### PR TITLE
chore: use built in caching from setup-node action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,9 +27,11 @@ jobs:
 
       - name: Setup node
         uses: guardian/actions-setup-node@main
+        with:
+          cache: 'yarn'
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn install --frozen-lockfile
 
       - name: Run unit tests
         run: 'yarn test --coverage --ci'
@@ -48,9 +50,11 @@ jobs:
 
       - name: Setup node
         uses: guardian/actions-setup-node@main
+        with:
+          cache: 'yarn'
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn install --frozen-lockfile
 
       - name: Lint files
         run: yarn lint
@@ -64,9 +68,11 @@ jobs:
 
       - name: Setup node
         uses: guardian/actions-setup-node@main
+        with:
+          cache: 'yarn'
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn install --frozen-lockfile
 
       - name: Check types
         run: yarn tsc
@@ -80,9 +86,11 @@ jobs:
 
       - name: Setup node
         uses: guardian/actions-setup-node@main
+        with:
+          cache: 'yarn'
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn install --frozen-lockfile
 
       - name: Build package
         run: yarn build
@@ -107,9 +115,11 @@ jobs:
 
       - name: Setup node
         uses: guardian/actions-setup-node@main
+        with:
+          cache: 'yarn'
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn install --frozen-lockfile
 
       - name: Fetch build
         uses: actions/download-artifact@v2


### PR DESCRIPTION
## What does this change?

This change updates the _ci_ workflow to use caching implemented by [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node) now that it's available. It also swaps out [bahmutov/npm-install](https://github.com/bahmutov/npm-install) for `yarn install --frozen-lockfile` as we no longer need the caching implemented by that action.
