### PR TITLE
chore: target a specific version of the actions-setup-node action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node
-        uses: guardian/actions-setup-node@main
+        uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
 
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node
-        uses: guardian/actions-setup-node@main
+        uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
 
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node
-        uses: guardian/actions-setup-node@main
+        uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
 
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node
-        uses: guardian/actions-setup-node@main
+        uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
 
@@ -114,7 +114,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup node
-        uses: guardian/actions-setup-node@main
+        uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
 


### PR DESCRIPTION
## What does this change?

Target a specific version of the [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node) action