### PR TITLE
fix: export `initCoreWebVitals`  method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@ export {
 	setCookie,
 	setSessionCookie,
 } from './cookies';
+export {
+	initCoreWebVitals,
+	bypassCoreWebVitalsSampling,
+} from './coreWebVitals';
 export type { Country } from './countries';
 export { countries, getCountryByCountryCode } from './countries';
 export type { CountryCode } from './@types/countries';


### PR DESCRIPTION
## What does this change?

Exports the method introduced in #280

## Why?

We can’t use it otherwise. Sorry @SiAdcock!