### PR TITLE
fix: update JSDoc to match documentation

### DIFF
--- a/src/coreWebVitals.README.md
+++ b/src/coreWebVitals.README.md
@@ -17,7 +17,7 @@ import { initCoreWebVitals, getCookie } from '@guardian/libs';
 // browserId & pageViewId are needed to join up the data downstream.
 const init: InitCoreWebVitalsOptions = {
     browserId : getCookie({ name: 'bwid', shouldMemoize: true}),
-    pageViewId: guardian.ophan.config.pageViewId,
+    pageViewId: guardian.config.ophan.pageViewId,
 
     // Whether to use CODE or PROD endpoints.
     isDev: window.location.hostname !== 'www.theguardian.com',

--- a/src/coreWebVitals.ts
+++ b/src/coreWebVitals.ts
@@ -145,7 +145,7 @@ export const bypassCoreWebVitalsSampling = (team?: TeamName): void => {
  * @param init - the initialisation options
  * @param init.isDev - used to determine whether to use CODE or PROD endpoints.
  * @param init.browserId - identifies the browser. Usually available via `getCookie({ name: 'bwid' })`. Defaults to `null`
- * @param init.pageViewId - identifies the page view. Usually available on `guardian.ophan.pageViewId`. Defaults to `null`
+ * @param init.pageViewId - identifies the page view. Usually available on `guardian.config.ophan.pageViewId`. Defaults to `null`
  *
  * @param init.sampling - sampling rate for sending data. Defaults to `0.01`.
  *


### PR DESCRIPTION
## What does this change?

Matches JSDoc to documentation

## Why?

@oliverlloyd has mentioned this is the proper way
