### PR TITLE
feat: Added `whenIdle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Turns absolute dates into time ago strings.
 
 Combines separate url parts into one valid url string.
 
+### [`whenIdle`](./src/whenIdle.README.md)
+
+Defers code execution until the browser is idle.
+
 ## Installation
 
 [![Generic badge](https://img.shields.io/badge/google-chat-259082.svg)](https://chat.google.com/room/AAAAWwBdSMs)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - [`storage`](#storage)
   - [`timeAgo`](#timeago)
   - [`joinUrl`](#joinurl)
+  - [`whenIdle`](#whenidle)
 - [Installation](#installation)
   - [Bundling](#bundling)
 - [Development](#development)

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@rollup/plugin-typescript": "8.2.5",
     "@semantic-release/github": "7.2.3",
     "@types/jest": "27.0.1",
+    "@types/requestidlecallback": "0.3.4",
     "@types/wcag-contrast": "3.0.0",
     "conventional-changelog-conventionalcommits": "4.6.0",
     "eslint": "7.32.0",

--- a/src/whenIdle.README.md
+++ b/src/whenIdle.README.md
@@ -1,0 +1,15 @@
+# `whenIdle()`
+
+Returns: `void`
+
+Runs the given callback when it detects that the browser is idle or if 500ms has passed
+
+## Example
+
+```js
+import { whenIdle } from '@guardian/libs';
+
+whenIdle(function () {
+    console.log('The browser is idle');
+});
+```

--- a/src/whenIdle.test.ts
+++ b/src/whenIdle.test.ts
@@ -1,0 +1,23 @@
+import { whenIdle } from './whenIdle';
+
+describe('whenIdle', () => {
+	it('does not fire callback straight away', () => {
+		let fired = false;
+		const cb = () => {
+			fired = true;
+		};
+		whenIdle(cb);
+		expect(fired).toBe(false);
+	});
+
+	it('fires the callback after 600ms', async () => {
+		let fired = false;
+		const cb = () => {
+			fired = true;
+		};
+		whenIdle(cb);
+		expect(fired).toBe(false);
+		await new Promise((r) => setTimeout(r, 600));
+		expect(fired).toBe(true);
+	});
+});

--- a/src/whenIdle.ts
+++ b/src/whenIdle.ts
@@ -1,0 +1,12 @@
+/**
+ * whenIdle executes the given callback when the browser is 'idle'
+ *
+ * @param callback Fired when requestIdleCallback runs or, if requestIdleCallback is not available, after 300ms
+ */
+export const whenIdle = (callback: () => void): void => {
+	if ('requestIdleCallback' in window) {
+		window.requestIdleCallback(callback, { timeout: 500 });
+	} else {
+		setTimeout(callback, 300);
+	}
+};

--- a/src/whenIdle.ts
+++ b/src/whenIdle.ts
@@ -2,10 +2,19 @@
  * whenIdle executes the given callback when the browser is 'idle'
  *
  * @param callback Fired when requestIdleCallback runs or, if requestIdleCallback is not available, after 300ms
+ * @param options Options for requestIdleCallback
+ * @param options.timeout How long to wait for requestIdleCallback to return, defaults to 500ms
  */
-export const whenIdle = (callback: () => void): void => {
+export const whenIdle = (
+	callback: () => void,
+	options: {
+		timeout: number;
+	} = {
+		timeout: 500,
+	},
+): void => {
 	if ('requestIdleCallback' in window) {
-		window.requestIdleCallback(callback, { timeout: 500 });
+		window.requestIdleCallback(callback, options);
 	} else {
 		setTimeout(callback, 300);
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,6 +1102,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.0.tgz#2e8332cc7363f887d32ec5496b207d26ba8052bb"
   integrity sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==
 
+"@types/requestidlecallback@0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@types/requestidlecallback/-/requestidlecallback-0.3.4.tgz#819e22b8994cf547e1f17f9cb79805a5a3bb1db5"
+  integrity sha512-aTSyiZuRemRLTQkJPb25L7A4/eR2Teo5l4yJ1V6P3+MFxEZckTDkNKNtr/V1zEOMzS6H8DgxF22U6jPAPrzQvw==
+
 "@types/retry@^0.12.0":
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"


### PR DESCRIPTION
## What?
`whenIdle` is a function that takes a callback which is executed either:

when `window.requestIdleCallback` runs
when the 500ms timeout is reached
or, if `requestIdleCallback` is not supported, after 300ms

## Why?
This offers people a utility for deferring code execution.

This function is proposed in [this PR for React Islands](https://github.com/guardian/dotcom-rendering/pull/3629) but it is also something that could be useful in the work to [defer downloading YouTube javascript](https://github.com/guardian/atoms-rendering/pull/303).
