### PR TITLE
feat: add pinned post component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ coverage
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea

--- a/src/@types/ophan.ts
+++ b/src/@types/ophan.ts
@@ -63,7 +63,8 @@ type OphanComponentType =
 	| 'SIGN_IN_GATE'
 	| 'RETENTION_ENGAGEMENT_BANNER'
 	| 'RETENTION_EPIC'
-	| 'CONSENT';
+	| 'CONSENT'
+	| 'LIVE-BLOG-PINNED-POST';
 
 type OphanComponent = {
 	componentType: OphanComponentType;

--- a/src/@types/ophan.ts
+++ b/src/@types/ophan.ts
@@ -64,7 +64,7 @@ type OphanComponentType =
 	| 'RETENTION_ENGAGEMENT_BANNER'
 	| 'RETENTION_EPIC'
 	| 'CONSENT'
-	| 'LIVE-BLOG-PINNED-POST';
+	| 'LIVE_BLOG_PINNED_POST';
 
 type OphanComponent = {
 	componentType: OphanComponentType;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Adding a new component LIVE-BLOG-PINNED-POST to track the new live blog feature where a post can be pinned at the top of a liveblog.

This has already been created and deployed in Ophan: https://github.com/guardian/ophan/pull/4337

More details about what kind of questions we'll be answering using this component on this card: https://trello.com/c/ZOVxR6F5/179-tracking-for-pinned-posts


