### PR TITLE
feat: add sticky_video to ophan component type

### DIFF
--- a/src/@types/ophan/index.ts
+++ b/src/@types/ophan/index.ts
@@ -38,7 +38,9 @@ type OphanAction =
 	| 'ACCEPT_DEFAULT_CONSENT'
 	| 'MANAGE_CONSENT'
 	| 'CONSENT_ACCEPT_ALL'
-	| 'CONSENT_REJECT_ALL';
+	| 'CONSENT_REJECT_ALL'
+	| 'STICK'
+	| 'CLOSE';
 
 type OphanComponentType =
 	| 'READERS_QUESTIONS_ATOM'
@@ -64,7 +66,8 @@ type OphanComponentType =
 	| 'RETENTION_ENGAGEMENT_BANNER'
 	| 'RETENTION_EPIC'
 	| 'CONSENT'
-	| 'LIVE_BLOG_PINNED_POST';
+	| 'LIVE_BLOG_PINNED_POST'
+	| 'STICKY_VIDEO';
 
 type OphanComponent = {
 	componentType: OphanComponentType;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
This PR adds a new component STICKY_VIDEO and also adds two actions STICK & CLOSE to ophan types.
## Why?
In order to emit tracking event to ophan when a sticky video sticks to screen and when the sticky video is closed.

Another PR is created in ophan to add these to the thrift https://github.com/guardian/ophan/pull/4440