### PR TITLE
feat: add RETURN to ophan actions

### DIFF
--- a/src/@types/ophan/index.ts
+++ b/src/@types/ophan/index.ts
@@ -40,7 +40,8 @@ type OphanAction =
 	| 'CONSENT_ACCEPT_ALL'
 	| 'CONSENT_REJECT_ALL'
 	| 'STICK'
-	| 'CLOSE';
+	| 'CLOSE'
+	| 'RETURN';
 
 type OphanComponentType =
 	| 'READERS_QUESTIONS_ATOM'


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
This PR adds a new action RETURN to ophan types. 

## Why?
In order to emit tracking event to ophan when a sticky video is returned to its original location.

Another PR is created in ophan to add this action to the thrift https://github.com/guardian/ophan/pull/4440