### PR TITLE
feat!: Load `web-vitals` asynchronously

### DIFF
--- a/src/coreWebVitals/index.test.ts
+++ b/src/coreWebVitals/index.test.ts
@@ -60,11 +60,10 @@ const mockConsoleWarn = jest
 
 const spyLog = jest.spyOn(logger, 'log');
 
-const setVisibilityState = (value: DocumentVisibilityState = 'visible') => {
+const setVisibilityState = (value: VisibilityState = 'visible') => {
 	Object.defineProperty(document, 'visibilityState', {
 		writable: true,
 		configurable: true,
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- missing type declaration
 		value,
 	});
 };

--- a/src/coreWebVitals/index.ts
+++ b/src/coreWebVitals/index.ts
@@ -118,14 +118,14 @@ type InitCoreWebVitalsOptions = {
 /**
  * Initialise sending Core Web Vitals metrics to a logging endpoint.
  *
- * @param init - the initialisation options
+ * @param {InitCoreWebVitalsOptions} init - the initialisation options
  * @param init.isDev - used to determine whether to use CODE or PROD endpoints.
  * @param init.browserId - identifies the browser. Usually available via `getCookie({ name: 'bwid' })`. Defaults to `null`
  * @param init.pageViewId - identifies the page view. Usually available on `guardian.config.ophan.pageViewId`. Defaults to `null`
  *
  * @param init.sampling - sampling rate for sending data. Defaults to `0.01`.
  *
- * @param team - Optional team to trigger a log event once metrics are queued.
+ * @param init.team - Optional team to trigger a log event once metrics are queued.
  */
 export const initCoreWebVitals = async ({
 	browserId = null,


### PR DESCRIPTION
## What does this change?

Prevents loading the `web-vitals` module when the user is not in the sampling group and the sampling has not been bypassed.

## Why?

Less JS sent to the vast majority (~99%) of our users.