### PR TITLE
fix: time separator is `.`

### DIFF
--- a/src/datetime/timeAgo.test.ts
+++ b/src/datetime/timeAgo.test.ts
@@ -72,7 +72,7 @@ describe('timeAgo', () => {
 		const yesterday = new Date(Date.UTC(2019, 10, 16, 3, 0, 0)).getTime();
 
 		expect(timeAgo(yesterday)).toBe('1d ago');
-		expect(timeAgo(yesterday, { verbose: true })).toBe('Yesterday 3:00');
+		expect(timeAgo(yesterday, { verbose: true })).toBe('Yesterday 3.00');
 	});
 
 	it('does not pluralise the unit when the delta is one', () => {
@@ -101,7 +101,7 @@ describe('timeAgo', () => {
 			timeAgo(oneDayAgo, {
 				verbose: true,
 			}),
-		).toBe('Yesterday 12:00');
+		).toBe('Yesterday 12.00');
 	});
 
 	it('returns verbose format for seconds when this option is given', () => {
@@ -172,7 +172,7 @@ describe('timeAgo', () => {
 			timeAgo(thirtyHoursAgo, {
 				verbose: true,
 			}),
-		).toBe('Yesterday 6:00');
+		).toBe('Yesterday 6.00');
 	});
 
 	it('returns absolute format dates for dates over one week ago, regardless of options', () => {

--- a/src/datetime/timeAgo.ts
+++ b/src/datetime/timeAgo.ts
@@ -36,7 +36,7 @@ const pad = (n: number): number | string => n.toString().padStart(2, '0');
 
 const isWithin24Hours = (date: Date): boolean => {
 	const today = new Date();
-	return date.valueOf() > today.valueOf() - 24 * 60 * 60 * 1000;
+	return date.getTime() > today.getTime() - 24 * 60 * 60 * 1000;
 };
 
 const isYesterday = (relative: Date): boolean => {

--- a/src/datetime/timeAgo.ts
+++ b/src/datetime/timeAgo.ts
@@ -19,7 +19,7 @@ const shortMonth = (month: number): string =>
 const longMonth = (month: number): string =>
 	[
 		'January',
-		'Febuary',
+		'February',
 		'March',
 		'April',
 		'May',

--- a/src/datetime/timeAgo.ts
+++ b/src/datetime/timeAgo.ts
@@ -75,6 +75,19 @@ const getSuffix = (type: Unit, value: number, verbose?: boolean): string => {
 const withTime = (date: Date): string =>
 	` ${date.getHours()}.${pad(date.getMinutes())}`;
 
+/**
+ * Takes an absolute date in [epoch format] and returns a string representing
+ * relative time ago.
+ *
+ * Time is formatted according to [the Guardian and Observer Style Guide (T)][T]
+ *
+ * @param {number} epoch The date when an event happened in epoch format
+ * @param {Object} [options] Options to control the formatting
+ * @returns {string | false} A formatted relative time string, or `false` if the epoch is in the future
+ *
+ * [epoch format]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#description
+ * [T]: https://www.theguardian.com/guardian-observer-style-guide-t
+ */
 export const timeAgo = (
 	epoch: number,
 	options?: {

--- a/src/datetime/timeAgo.ts
+++ b/src/datetime/timeAgo.ts
@@ -65,7 +65,7 @@ const getSuffix = (type: Unit, value: number, verbose?: boolean): string => {
 			return 'h ago';
 		}
 		case 'd': {
-			// Always pluralised, as less than 2 days returns “Yesterday HH:MM”
+			// Always pluralised, as less than 2 days returns “Yesterday HH.MM”
 			if (verbose) return ' days ago';
 			return 'd ago';
 		}
@@ -73,7 +73,7 @@ const getSuffix = (type: Unit, value: number, verbose?: boolean): string => {
 };
 
 const withTime = (date: Date): string =>
-	` ${date.getHours()}:${pad(date.getMinutes())}`;
+	` ${date.getHours()}.${pad(date.getMinutes())}`;
 
 export const timeAgo = (
 	epoch: number,


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Fixes the time separator for the `withTime` method.

## Why?

From [the Guardian and Observer style guide: T][T]

> **times**
> 1am, 6.30pm, etc; 10 o’clock last night but 10pm yesterday; half past two, a quarter to three, 10 to 11, etc; 2hr 5min 6sec, etc; for 24-hour clock, 00.47, 23.59; noon, midnight (not 12 noon, 12 midnight or 12am, 12pm).

[T]: https://www.theguardian.com/guardian-observer-style-guide-t