### PR TITLE
refactor(getCookie): get the value directly

### DIFF
--- a/src/cookies/getCookie.ts
+++ b/src/cookies/getCookie.ts
@@ -15,9 +15,8 @@ export const getCookie = ({
 	name: string;
 	shouldMemoize?: boolean;
 }): string | null => {
-	if (memoizedCookies.has(name)) {
-		return memoizedCookies.get(name) ?? null;
-	}
+	const memoized = memoizedCookies.get(name);
+	if (memoized) return memoized;
 
 	const cookieVal = getCookieValues(name);
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Refactor the map check in getCookie to always `get`, instead of checking `has` before.

## Why?

Currently, we don’t have 100% coverage because of [a TS limitation](https://github.com/microsoft/TypeScript/issues/9619#issuecomment-473669366).
There’s safety built-in the get method, so let’s use it directly.

We could alternatively use a `//@ts-expect-error` or an `as string` type assertion.
