### PR TITLE
feat(ophan): Add `key_event_card` ophan component type

### DIFF
--- a/src/ophan/@types/index.ts
+++ b/src/ophan/@types/index.ts
@@ -66,7 +66,8 @@ export type OphanComponentType =
 	| 'RETENTION_EPIC'
 	| 'CONSENT'
 	| 'LIVE_BLOG_PINNED_POST'
-	| 'STICKY_VIDEO';
+	| 'STICKY_VIDEO'
+	| 'KEY_EVENT_CARD';
 
 export type OphanComponent = {
 	componentType: OphanComponentType;


### PR DESCRIPTION
## What does this change?

This PR adds a `KEY_EVENT_CARD` Ophan component type.

## Why?

We're in the process of creating a new key events timeline carousel, the first step of which has been to create new key event cards: https://github.com/guardian/dotcom-rendering/pull/4696

In order to track clicks on these new cards, we need a new componentType.

The corresponding PR in Ophan is here: https://github.com/guardian/ophan/pull/4617
