### PR TITLE
chore: Add snyk monitoring for main branch

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,18 @@
+# This action runs snyk monitor on every push to main
+name: Snyk
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  security:
+    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
+    with:
+      DEBUG: true
+      ORG: guardian-csti 
+      SKIP_NODE: false
+    secrets:
+       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
This PR reliably integrates the repository with the snyk GitHub action which will scan your code’s dependencies and alert you if vulnerabilities are found. This PR has only been raised on repos that have already been tested to make sure scanning will work out of the box. ‘reliably integrated’ means that this action compares the hash of the last commit on main to the one that snyk has, and makes sure that they match. If you think that this repository doesn’t belong to your team, please mark your team as something other than an Admin for this repo before closing the PR, or its highly likely further PRs will be raised.