### PR TITLE
feat(ophan): add additional types to Ophan

### DIFF
--- a/src/ophan/@types/index.ts
+++ b/src/ophan/@types/index.ts
@@ -39,7 +39,9 @@ export type OphanAction =
 	| 'CONSENT_REJECT_ALL'
 	| 'STICK'
 	| 'CLOSE'
-	| 'RETURN';
+	| 'RETURN'
+	| 'SIGN_IN'
+	| 'CREATE_ACCOUNT';
 
 export type OphanComponentType =
 	| 'READERS_QUESTIONS_ATOM'
@@ -66,7 +68,8 @@ export type OphanComponentType =
 	| 'RETENTION_EPIC'
 	| 'CONSENT'
 	| 'LIVE_BLOG_PINNED_POST'
-	| 'STICKY_VIDEO';
+	| 'STICKY_VIDEO'
+	| 'IDENTITY_AUTHENTICATION';
 
 export type OphanComponent = {
 	componentType: OphanComponentType;


### PR DESCRIPTION
## What does this change?

The identity team use the `SIGN_IN` and `CREATE_ACCOUNT` action, which we noticed was missing from the `OphanAction` type, and the `IDENTITY_AUTHENTICATION` `OphanCompnent` type.

From the definitions in https://dashboard.ophan.co.uk/docs/thrift/componentevent.html

This PR adds those actions in so that they're available for use.
