### PR TITLE
chore(codeowners): remove old, add new CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,8 @@
 # if you would like to help maintain this repo,
 # please add yourself in a PR
 
-* @guardian/client-side-infra @gtrufitt
+* @guardian/client-side-infra
 
-src/coreWebVitals*  @guardian/guardian-frontend-team @guardian/commercial-dev
+src/coreWebVitals* @guardian/dotcom-platform @guardian/commercial-dev
+
+/src/format/ @guardian/apps-rendering @guardian/dotcom-platform


### PR DESCRIPTION
## What does this change?

The CODEOWNERS file was showing errors, fixed some of them in the following ways.

- `gtrufitt` no longer has access, removed from the file.
- `guardian-frontend-team` doesn't seem to exist any more, removed from the file. Added `dotcom-platform` instead.

Added `apps-rendering` and `dotcom-platform` as owners of the `format` module.

## Why?

GitHub was showing three errors in the CODEOWNERS file. I've fixed two of them as described above. There's still a problem with `commercial-dev`, and I can see a similar error has appeared for the new teams I've added. Perhaps we need to update the repo permissions for this to work?

I've made the `format` ownership change because I think the Apps-Rendering and Dotcom teams probably own this module and any downstream repos that will be affected by changes to it (DCR, AR, atoms-rendering)? Please let me know if this is an incorrect assumption!

**Note:** I've assumed `dotcom-platform` is a valid replacement for the `guardian-frontend-team` as an owner of the core web vitals module. If this is wrong please let me know!
