### PR TITLE
fix: remove type assertions from logger

### DIFF
--- a/scripts/generateSvg.logger.teams.ts
+++ b/scripts/generateSvg.logger.teams.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { teamStyles } from '../src/logger/teamStyles';
+import { commonStyle, teamStyles } from '../src/logger/teamStyles';
 
 fs.writeFileSync(__dirname + '/../static/logger.svg', generateSvg());
 
@@ -72,8 +72,8 @@ function generateSvg(): string {
 		}
 
 		.common {
-			background-color: ${teamStyles.common.background};
-			color: ${teamStyles.common.font};
+			background-color: ${commonStyle.common.background};
+			color: ${commonStyle.common.font};
 		}
 	</style>
 	<foreignObject x="0" y="0" width="${width}" height="${height}">

--- a/src/logger/@types/logger.ts
+++ b/src/logger/@types/logger.ts
@@ -1,7 +1,7 @@
-import type { teamStyles } from '../teamStyles';
+import type { commonStyle, teamStyles } from '../teamStyles';
 
 export type Teams<K extends string> = Record<K, Record<string, string>>;
 export type LogCall = (team: TeamName, ...args: unknown[]) => void;
 export type TeamSubscription = (arg: TeamName) => void;
-export type TeamStyle = keyof typeof teamStyles;
-export type TeamName = Exclude<TeamStyle, 'common'>;
+export type TeamStyle = TeamName | keyof typeof commonStyle;
+export type TeamName = keyof typeof teamStyles;

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -102,9 +102,7 @@ describe('Add and remove teams', () => {
 	});
 
 	it('should return the list of registered teams', () => {
-		let teams: string[] = [];
-		if (window.guardian?.logger) teams = window.guardian.logger.teams();
-		console.log(teams);
+		const teams = window.guardian?.logger?.teams();
 		expect(Array.isArray(teams)).toBe(true);
 		expect(teams).toContain('cmp');
 	});

--- a/src/logger/teamStyles.ts
+++ b/src/logger/teamStyles.ts
@@ -1,14 +1,20 @@
+import type { TeamName } from './@types/logger';
+
+/** Common Guardian blue label. Do not edit */
+const commonStyle = {
+	common: {
+		background: '#052962',
+		font: '#ffffff',
+	},
+} as const;
+
 /**
  * You can only subscribe to teams from this list.
  * Add your team name below to start logging.
  *
  * Make sure your label has a contrast ratio of 4.5 or more.
  * */
-export const teamStyles = {
-	common: {
-		background: '#052962',
-		font: '#ffffff',
-	},
+const teamStyles = {
 	commercial: {
 		background: '#77EEAA',
 		font: '#004400',
@@ -38,3 +44,8 @@ export const teamStyles = {
 		font: '#ffffff',
 	},
 } as const;
+
+const isTeam = (team: string): team is TeamName =>
+	Object.keys(teamStyles).includes(team);
+
+export { commonStyle, teamStyles, isTeam };


### PR DESCRIPTION
## What does this change?

Remove type assertions from logger by creating a `getTeamSubscriptions` abstraction.

## Why?

Checks unkown value at runtime for better type safety.
