### PR TITLE
feat(logger): add `identity` team to logger

### DIFF
--- a/src/logger/teamStyles.ts
+++ b/src/logger/teamStyles.ts
@@ -33,4 +33,8 @@ export const teamStyles = {
 		background: '#0F70B7',
 		font: '#ffffff',
 	},
+	identity: {
+		background: '#6F5F8F',
+		font: '#ffffff',
+	},
 } as const;

--- a/static/logger.svg
+++ b/static/logger.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 224" width="600" height="224">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 248" width="600" height="248">
 	<style>
 		.wrapper {
 			font-family: monospace;
@@ -50,7 +50,7 @@
 			color: #ffffff;
 		}
 	</style>
-	<foreignObject x="0" y="0" width="600" height="224">
+	<foreignObject x="0" y="0" width="600" height="248">
 		<div class="wrapper" xmlns="http://www.w3.org/1999/xhtml">
 			<div id="console">
 				<div class="line top">Console</div>
@@ -88,6 +88,12 @@
 			<span class="label common">@guardian</span>
 			<span class="label supporterRevenue" style="background-color: #0F70B7; color: #ffffff">supporterRevenue</span>
 			<span class="label">message no.5</span>
+			<span class="gap"></span>
+			<span class="label log">console.log</span>
+		</div><div class="line">
+			<span class="label common">@guardian</span>
+			<span class="label identity" style="background-color: #6F5F8F; color: #ffffff">identity</span>
+			<span class="label">message no.6</span>
 			<span class="gap"></span>
 			<span class="label log">console.log</span>
 		</div>


### PR DESCRIPTION
## What does this change?

Add the Identity team to the logger

## Why?

So the Identity team can use these logs to identify their own logs in other platforms, e.g. frontend/dcr, as well as our own.
