### PR TITLE
fix: export `TeamName` for `log`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export { getLocale } from './locale/getLocale';
 
 export { debug } from './logger/debug';
 export { log } from './logger/log';
+export type { TeamName } from './logger/@types/logger';
 
 export type {
 	OphanABEvent,


### PR DESCRIPTION
`log` takes a arg of type `TeamName`